### PR TITLE
flamerMotionの導入・1カラムページ用のコンポーネントの作成

### DIFF
--- a/app/components/1ColumnPage/Hero.tsx
+++ b/app/components/1ColumnPage/Hero.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import SignupButton from "../ui/SignupButton";
+
+const Hero = () => {
+  return (
+    <>
+      <div className="relative bg-sky-200 md:h-[600px] h-[300px] w-full flex items-center">
+        <Image
+          src="/hero_image.JPG"
+          alt="Description of your image"
+          priority
+          fill
+          style={{
+            objectFit: "cover",
+          }}
+        />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="flex-col justify-center items-center md:w-[440px] w-[340px] md:h-[260px] h-[240px]  py-4 px-2 bg-white md:opacity-90 opacity-80 rounded text-center">
+            <p className="font-semibold mb-3 text-lg md:text-2xl">
+              旅程表が作成できるしおりアプリ
+            </p>
+            <p className="font-bold mb-3 text-lg md:text-2xl text-sky-500">
+              「旅のメモリーブック」
+            </p>
+            <p className="mb-1">国内旅行・海外旅行で使える。</p>
+            <p>PC・スマホ・タブレット対応の無料アプリ</p>
+            <SignupButton />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Hero;

--- a/app/components/1ColumnPage/QA.tsx
+++ b/app/components/1ColumnPage/QA.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import AnimatedItem from "../lib/AnimatedItem";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faQ, faA, faPlus, faMinus } from "@fortawesome/free-solid-svg-icons";
+import { useState } from "react";
+
+type QAProps = {
+  title: string;
+  content: string;
+};
+
+const QA: React.FC<QAProps> = ({ title, content }) => {
+  const [isShowContent, setIsShowContent] = useState<boolean>(false);
+
+  const toggleShowContent = () => {
+    setIsShowContent((isShowContent) => !isShowContent);
+  };
+
+  return (
+    <>
+      <AnimatedItem
+        elementType="div"
+        animation="fadeInVariants"
+        className="border border-gray-600 my-10 p-8 rounded cursor-pointer w-full"
+        onClick={toggleShowContent}
+      >
+        {isShowContent ? (
+          <>
+            <div className="flex items-center mb-4 w-full">
+              <FontAwesomeIcon icon={faQ} className="mr-4" />
+              <h3 className="border-b border-dashed border-gray-600 py-2 w-full">
+                {title}
+              </h3>
+              <FontAwesomeIcon icon={faMinus} />
+            </div>
+            <div className="flex items-center">
+              <FontAwesomeIcon icon={faA} className="mr-4" />
+              <p className="py-4 leading-loose">{content}</p>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center mb-4 w-full">
+              <FontAwesomeIcon icon={faQ} className="mr-4" />
+              <h3 className="border-b border-dashed border-gray-600 py-2 w-full">
+                {title}
+              </h3>
+              <FontAwesomeIcon icon={faPlus} />
+            </div>
+          </>
+        )}
+      </AnimatedItem>
+    </>
+  );
+};
+
+export default QA;

--- a/app/components/1ColumnPage/Section.tsx
+++ b/app/components/1ColumnPage/Section.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+import AnimatedItem from "../lib/AnimatedItem";
+
+type SectionProps = {
+  children: ReactNode;
+  name: string;
+  bgColor: String;
+};
+
+const Section: React.FC<SectionProps> = ({ children, bgColor, name }) => {
+  return (
+    <section className={`${bgColor}`}>
+      <div className="max-w-[1150px] w-full py-2 md:py-6 px-4 mx-auto">
+        <AnimatedItem
+          elementType="div"
+          animation="fadeInVariants"
+          className="flex items-center mx-0 py-8  "
+        >
+          <span className="flex-grow h-1 w-5 md:w-0 mr-1 md:mr-4 bg-gradient-to-l from-gray-600 to-transparent"></span>
+          <h2 className="text-2xl md:text-3xl py-0 my-5 text-gray-700 text-center font-bold bg-transparent">
+            {name}
+          </h2>
+          <span className="flex-grow h-1 w-5 md:w-0 mr-1 md:mr-4 bg-gradient-to-r from-gray-600 to-transparent"></span>
+        </AnimatedItem>
+        {children}
+      </div>
+    </section>
+  );
+};
+
+export default Section;

--- a/app/components/1ColumnPage/Section1ColumnLeft.tsx
+++ b/app/components/1ColumnPage/Section1ColumnLeft.tsx
@@ -1,0 +1,45 @@
+import Image from "next/image";
+
+type Section1ColumnLeftProps = {
+  src: string;
+  alt: string;
+  name: string;
+  content: string;
+  content2?: string;
+  content3?: string;
+};
+
+const Section1ColumnLeft: React.FC<Section1ColumnLeftProps> = ({
+  src,
+  alt,
+  name,
+  content,
+  content2,
+  content3,
+}) => {
+  return (
+    <>
+      <div className="flex justify-center  w-full  my-20 py-16 border border-sky-600  rounded flex-wrap">
+      <div className="w-full py-4 mx-14 max-w-[400px] justify-center items-center">
+          <h3 className="text-gray-700 mb-6 text-2xl font-semibold ">
+            {name}
+          </h3>
+          <p className="text-gray-700 mb-6">{content}</p>
+          <p className="text-gray-700 mb-6">{content2}</p>
+          <p className="text-gray-700 mb-6">{content3}</p>
+
+        </div>
+        <div className="w-full flex justify-center items-center py-4  max-w-[400px] ">
+          <Image
+            src={src}
+            alt={alt}
+            width={350}
+            height={250}
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Section1ColumnLeft;

--- a/app/components/1ColumnPage/Section1ColumnRight.tsx
+++ b/app/components/1ColumnPage/Section1ColumnRight.tsx
@@ -1,0 +1,61 @@
+import Image from "next/image";
+import AnimatedItem from "../lib/AnimatedItem";
+
+type Section1ColumnRightProps = {
+  src: string;
+  alt: string;
+  isPriority?: boolean;
+  name: string;
+  content: string;
+  content2?: string;
+  content3?: string;
+};
+
+const Section1ColumnRight: React.FC<Section1ColumnRightProps> = ({
+  src,
+  alt,
+  isPriority,
+  name,
+  content,
+  content2,
+  content3,
+}) => {
+  return (
+    <>
+      <AnimatedItem
+        elementType="h3"
+        animation="fadeInVariants"
+        className="text-gray-700 my-6 w-[80%] flex justify-center pb-2 text-xl md:text-2xl font-semibold border-b text-center border-sky-700 border-dashed mx-auto"
+      >
+        {name}
+      </AnimatedItem>
+      <AnimatedItem
+        elementType="div"
+        animation="fadeInVariants"
+        className="flex justify-center w-full py-1 md:py-4 mb-4 rounded flex-wrap"
+      >
+        <div className="w-full flex justify-center items-center py-4 max-w-[400px]">
+            <Image
+              src={src}
+              alt={alt}
+              width={360}
+              height={260}
+              style={{
+                width: "365px",
+                height: "auto",
+              }}
+              priority={isPriority}
+              className="border border-gray-200"
+            />
+        </div>
+        <div className="w-full py-2 md:py-8 md:mx-6 max-w-[400px] justify-center items-center">
+          <p className="text-gray-700 mb-6">{content}</p>
+          <p className="text-gray-700 mb-6">{content2}</p>
+          <p className="text-gray-700 mb-6">{content3}</p>
+        </div>
+      </AnimatedItem>
+    </>
+  );
+};
+
+export default Section1ColumnRight;

--- a/app/components/1ColumnPage/Section3ColumnIcon.tsx
+++ b/app/components/1ColumnPage/Section3ColumnIcon.tsx
@@ -1,0 +1,80 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faEarthAsia,
+  faPlaneDeparture,
+  faCartFlatbedSuitcase,
+} from "@fortawesome/free-solid-svg-icons";
+
+import AnimatedItem from "../lib/AnimatedItem";
+
+type Section3ColumnIconProps = {
+  name1: string;
+  name2: string;
+  name3: string;
+  content1: string;
+  content2: string;
+  content3: string;
+};
+
+const Section3ColumnIcon: React.FC<Section3ColumnIconProps> = ({
+  name1,
+  name2,
+  name3,
+  content1,
+  content2,
+  content3,
+}) => {
+  return (
+    <div className="flex w-full my-10 flex-wrap items-center justify-center">
+      <AnimatedItem
+        animation="fadeInVariants"
+        elementType="div"
+        className="border-2 border-sky-600 rounded w-[28%] mx-2 my-4 px-4 md:px-8 py-6 flex flex-col min-w-[330px] min-h-[330px]"
+      >
+        <span className="text-blue-500  flex justify-center mb-6">
+          <FontAwesomeIcon icon={faEarthAsia} style={{ fontSize: "2em" }} />
+        </span>
+        <h3 className="text-gray-700 mb-6 text-center text-xl font-semibold">
+          {name1}
+        </h3>
+        <p className="text-gray-700 mb-6">{content1}</p>
+      </AnimatedItem>
+      <AnimatedItem
+        animation="fadeInVariants"
+        elementType="div"
+        delay={0.3}
+        className="border-2 border-sky-600 rounded w-[28%] mx-2 my-4 px-4 md:px-8 py-6 flex flex-col min-w-[330px] min-h-[330px]"
+      >
+        <span className="text-blue-500  flex justify-center mb-6">
+          <FontAwesomeIcon
+            icon={faPlaneDeparture}
+            style={{ fontSize: "2em" }}
+          />
+        </span>
+        <h3 className="text-gray-700 mb-6 text-center text-xl font-semibold">
+          {name2}
+        </h3>
+        <p className="text-gray-700 mb-6">{content2}</p>
+      </AnimatedItem>
+      <AnimatedItem
+        animation="fadeInVariants"
+        elementType="div"
+        delay={0.6}
+        className="border-2 border-sky-600 rounded w-[28%] mx-2 my-4 px-4 md:px-8 py-6 flex flex-col min-w-[330px] min-h-[330px]"
+      >
+        <span className="text-blue-500  flex justify-center mb-6">
+          <FontAwesomeIcon
+            icon={faCartFlatbedSuitcase}
+            style={{ fontSize: "2em" }}
+          />
+        </span>
+        <h3 className="text-gray-700 mb-6 text-center text-xl font-semibold">
+          {name3}
+        </h3>
+        <p className="text-gray-700 mb-6">{content3}</p>
+      </AnimatedItem>
+    </div>
+  );
+};
+
+export default Section3ColumnIcon;

--- a/app/components/1ColumnPage/Section3ColumnImage.tsx
+++ b/app/components/1ColumnPage/Section3ColumnImage.tsx
@@ -1,0 +1,136 @@
+import Image from "next/image";
+import AnimatedItem from "../lib/AnimatedItem";
+
+type Section3ColumnImageProps = {
+  title1: string;
+  title2: string;
+  title3: string;
+  content1: string;
+  content2: string;
+  content3: string;
+  image1Url: string;
+  image2Url: string;
+  image3Url: string;
+  image1Alt: string;
+  image2Alt: string;
+  image3Alt: string;
+};
+
+const Section3ColumnImage: React.FC<Section3ColumnImageProps> = ({
+  title1,
+  title2,
+  title3,
+  content1,
+  content2,
+  content3,
+  image1Url,
+  image2Url,
+  image3Url,
+  image1Alt,
+  image2Alt,
+  image3Alt,
+}) => {
+  return (
+    <>
+      <div className="flex w-full my-8 flex-wrap items-center justify-center">
+        <AnimatedItem
+          elementType="div"
+          animation="fadeInVariants"
+          className="my-6 flex flex-col  items-center max-w-[320px] min-w-[320px] rounded"
+        >
+          <div className="min-h-[222px] max-h-[222px] border justify-centers">
+            <figure
+              style={{
+                position: "relative",
+                width: "320px",
+                height: "220px",
+              }}
+            >
+              <Image
+                src={image1Url}
+                alt={image1Alt}
+                fill
+                sizes="(max-hight: 220px)"
+                style={{
+                  objectFit: "cover",
+                }}
+              />
+            </figure>
+          </div>
+          <div className="min-h-[130px] ">
+            <h3 className="text-gray-700 my-6 text-center text-xl font-semibold">
+              {title1}
+            </h3>
+            <p className="text-gray-600 my-2">{content1}</p>
+          </div>
+        </AnimatedItem>
+        <AnimatedItem
+          elementType="div"
+          animation="fadeInVariants"
+          delay={0.3}
+          className="rounded my-6 flex flex-col mx-0 md:mx-8 items-center max-w-[320px] min-w-[320px]"
+        >
+          <div className="min-h-[222px] max-h-[222px] border justify-centers">
+            <figure
+              style={{
+                position: "relative",
+                width: "320px",
+                height: "220px",
+              }}
+            >
+              <Image
+                src={image2Url}
+                alt={image2Alt}
+                fill
+                sizes="(max-hight: 220px)"
+                style={{
+                  objectFit: "cover",
+                }}
+              />
+            </figure>
+          </div>
+          <div className="min-h-[130px] ">
+            <h3 className="text-gray-700 my-6 text-center text-xl font-semibold">
+              {title2}
+            </h3>
+            <p className="text-gray-600 my-2">{content2}</p>
+          </div>
+        </AnimatedItem>
+        <AnimatedItem
+          elementType="div"
+          animation="fadeInVariants"
+          delay={0.6}
+          className="my-6 flex flex-col items-center max-w-[320px] min-w-[320px] rounded"
+        >
+          <div className="min-h-[222px] max-h-[222px]  border justify-centers">
+            <figure
+              style={{
+                position: "relative",
+                width: "320px",
+                height: "220px",
+              }}
+            >
+              <Image
+                src={image3Url}
+                alt={image3Alt}
+                fill
+                sizes="(max-hight: 220px)"
+                style={{
+                  objectFit: "cover",
+                }}
+              />
+            </figure>
+          </div>
+          <div className="min-h-[130px] ">
+            <h3 className="text-gray-700 my-6 text-center text-xl font-semibold">
+              {title3}
+            </h3>
+            <p className="text-gray-600 my-2">{content3} </p>
+          </div>
+        </AnimatedItem>
+      </div>
+    </>
+  );
+};
+
+export default Section3ColumnImage;

--- a/app/components/1ColumnPage/SectionCTA.tsx
+++ b/app/components/1ColumnPage/SectionCTA.tsx
@@ -1,0 +1,48 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPenToSquare } from "@fortawesome/free-regular-svg-icons";
+import AnimatedItem from "../lib/AnimatedItem";
+
+type SectionCTAProps = {
+  name1: string;
+  name2: string;
+  name3: string;
+  content: string;
+};
+
+const SectionCTA: React.FC<SectionCTAProps> = ({
+  name1,
+  name2,
+  name3,
+  content,
+}) => {
+  return (
+      <AnimatedItem elementType="div" animation="fadeInVariants">
+        <ul className="my-12 p-6 border border-dashed border-gray-500">
+          <li className="mb-4 text-red-500">
+            <FontAwesomeIcon
+              icon={faPenToSquare}
+              className="text-sky-700 mr-4"
+            />
+            {name1}
+          </li>
+          <li className="mb-4 text-red-500">
+            <FontAwesomeIcon
+              icon={faPenToSquare}
+              className="text-sky-700 mr-4"
+            />
+            {name2}
+          </li>
+          <li className="text-red-500">
+            <FontAwesomeIcon
+              icon={faPenToSquare}
+              className="text-sky-700 mr-4"
+            />
+            {name3}
+          </li>
+        </ul>
+        <p className="text-center text-gray-700 mb-6">{content}</p>
+      </AnimatedItem>
+  );
+};
+
+export default SectionCTA;

--- a/app/components/lib/AnimatedImage.tsx
+++ b/app/components/lib/AnimatedImage.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+type AnimatedImageProps = {
+  animation: "fadeInRightImage" | "footerImage" | "fadeIntImage";
+  src: string;
+  width: string;
+  height: string;
+  alt: string;
+  className?: string;
+  onClick?: (e: React.MouseEvent) => void;
+  delay?: number;
+};
+
+const AnimatedImage: React.FC<AnimatedImageProps> = ({
+  className,
+  animation,
+  onClick,
+  src,
+  width,
+  height,
+  alt,
+  delay,
+}) => {
+  const fadeInRightImage = {
+    hidden: { opacity: 0, x: "300%" },
+    visible: {
+      opacity: 1,
+      x: "0%",
+      transition: {
+        delay: delay || 0,
+        duration: 3,
+      },
+    },
+  };
+
+  const fadeIntImage = {
+    hidden: { opacity: 0, y: 40 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        delay: delay || 0,
+        duration: 1.0,
+      },
+    },
+  };
+
+  const footerImage = {
+    hidden: { opacity: 0.7, x: "150%", y: "-80%" },
+    visible: {
+      opacity: 0,
+      x: "-100%",
+      y: "-300%",
+      transition: {
+        delay: delay || 0,
+        duration: 3,
+      },
+    },
+  };
+
+  const animations = {
+    fadeInRightImage,
+    footerImage,
+    fadeIntImage,
+  };
+
+  return (
+    <motion.img
+      src={src}
+      width={width}
+      height={height}
+      alt={alt}
+      variants={animations[animation]}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+      className={className}
+      onClick={onClick}
+    />
+  );
+};
+
+export default AnimatedImage;

--- a/app/components/lib/AnimatedItem.tsx
+++ b/app/components/lib/AnimatedItem.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ReactNode } from "react";
+
+type AnimatedItemProps = {
+  elementType: "div" | "h2" | "h3" | "li" | "p";
+  className?: string;
+  children: ReactNode;
+  animation:
+    | "fadeInVariants"
+    | "fadeInAndScaleVariants"
+    | "fadeInLeftVariants"
+    | "borderVariants";
+  onClick?: (e: React.MouseEvent) => void;
+  imageUrl?: string;
+  delay?: number;
+};
+
+const AnimatedItem: React.FC<AnimatedItemProps> = ({
+  className,
+  children,
+  elementType,
+  animation,
+  onClick,
+  imageUrl,
+  delay,
+}) => {
+  const MotionComponent = motion[elementType];
+
+  const fadeInVariants = {
+    hidden: { opacity: 0, y: 40 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        delay: delay || 0,
+        duration: 1.0,
+      },
+    },
+  };
+
+  const fadeInAndScaleVariants = {
+    hidden: { opacity: 0, y: 20, scale: 0.5 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      scale: 1,
+      transition: {
+        delay: delay || 0,
+        duration: 1.0,
+      },
+    },
+  };
+
+  const fadeInLeftVariants = {
+    hidden: { opacity: 0, x: -300 },
+    visible: {
+      opacity: 1,
+      x: 0,
+      transition: {
+        delay: delay || 0,
+        duration: 1.8,
+      },
+    },
+  };
+
+  const borderVariants = {
+    hidden: {
+      width: 0,
+      x: "100%",
+    },
+    visible: {
+      width: "100%",
+      x: "0%",
+      transition: {
+        duration: 7.0,
+      },
+    },
+  };
+
+  const animations = {
+    fadeInVariants,
+    fadeInAndScaleVariants,
+    fadeInLeftVariants,
+    borderVariants,
+  };
+
+  return (
+    <MotionComponent
+      variants={animations[animation]}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+      className={className}
+      onClick={onClick}
+      style={imageUrl ? { backgroundImage: `url('${imageUrl}')` } : undefined}
+    >
+      {children}
+    </MotionComponent>
+  );
+};
+
+export default AnimatedItem;

--- a/app/components/ui/SignupButton.tsx
+++ b/app/components/ui/SignupButton.tsx
@@ -2,11 +2,7 @@
 
 import useSignupModal from "../auth/hooks/useSignupModal";
 
-type SignupButtonProps = {
-  children: React.ReactNode;
-};
-
-const SignupButton: React.FC<SignupButtonProps> = ({ children }) => {
+const SignupButton = () => {
   const signupModal = useSignupModal();
 
   return (
@@ -17,7 +13,7 @@ const SignupButton: React.FC<SignupButtonProps> = ({ children }) => {
         }}
         className="px-16 py-3 shadow font-bold bg-sky-700 text-white hover:bg-white hover:text-black border border-sky-900"
       >
-        {children}
+        しおりを作成
       </button>
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@supabase/supabase-js": "^2.42.4",
+        "framer-motion": "^11.1.7",
         "next": "14.1.4",
         "next-auth": "^4.24.7",
         "react": "^18",
@@ -2413,6 +2414,30 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.1.7.tgz",
+      "integrity": "sha512-cW11Pu53eDAXUEhv5hEiWuIXWhfkbV32PlgVISn7jRdcAiVrJ1S03YQQ0/DzoswGYYwKi4qYmHHjCzAH52eSdQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@supabase/supabase-js": "^2.42.4",
+    "framer-motion": "^11.1.7",
     "next": "14.1.4",
     "next-auth": "^4.24.7",
     "react": "^18",


### PR DESCRIPTION
## flamerMotionの導入と専用のコンポーネントの作成
[flamerMotionの導入とコンポーネントの作成](https://github.com/haru0354/next-blog-isr/commit/e2c5865421da559cd34ae36035e6ca925288cd70)

flamerMotionの動作はpropsを渡すことで、どのアニメーションをするかなど、制御できるように作成。

## 1カラムページ用のコンポーネントの作成
- [sectionコンポーネントの作成](https://github.com/haru0354/next-blog-isr/commit/f10f89a021b136f5708104c74c65135280ef0e5f)
- [１カラム用の画像とテキストの横並びのセクションの作成](https://github.com/haru0354/next-blog-isr/commit/7fa200dbb0f86547ee70f171f8ef2463589e6a7a)
- [３列のアイコンとテキストのセクションの作成](https://github.com/haru0354/next-blog-isr/commit/085758dcb1b2e74deaeb3e3ef3590c2dc5f05c38)
- [3列の画像とテキストのセクションの作成](https://github.com/haru0354/next-blog-isr/commit/e12a5443182023f9ad34dd21cd3ceaf5d9da105d)
- [CTAのセクションの作成](https://github.com/haru0354/next-blog-isr/commit/61e14984fd9ce2bc96131f629232b8ee7ef4bb82)
- [qaセクションの作成](https://github.com/haru0354/next-blog-isr/commit/737129af8f41022786e4e9271aa4917547095b6f)
- [heroセクションの作成](https://github.com/haru0354/next-blog-isr/commit/36784965f1ac3031e051e80855167273103154f6)

アプリ用の説明ページで使えるコンポーネントの作成。
アプリのTOPページでの使用を前提に、コンポーネントを複数作成している。




