### PR TITLE
ブログの個別記事・カテゴリページ・サイドバーの作成

### DIFF
--- a/app/(blog)/[category_slug]/[post_slug]/page.tsx
+++ b/app/(blog)/[category_slug]/[post_slug]/page.tsx
@@ -1,0 +1,56 @@
+import NotFound from "@/app/not-found";
+import ArticleContentArea from "@/app/components/blog/blogContent/ArticleContentArea";
+import ArticleTop from "@/app/components/blog/blogContent/ArticleTop";
+import Breadcrumbs from "@/app/components/blog/Breadcrumbs";
+import SideMenu from "@/app/components/blog/SideMenu";
+
+import { getPost } from "@/app/components/lib/BlogServiceUnique";
+import { getPosts } from "@/app/components/lib/BlogServiceMany";
+
+export async function generateStaticParams() {
+  const posts = await getPosts("categoryAndPostImage");
+
+  return posts.map((post) => ({
+    params: {
+      post_slug: post.slug,
+    },
+    revalidate: 60 * 60 * 24 * 15, 
+  }));
+}
+
+const Page = async ({ params }: { params: { post_slug: string } }) => {
+  const post = await getPost("slug", params.post_slug, "categoryAndPostImage");
+
+  if (!post || post.draft === false) {
+    return (
+      <div>
+        <NotFound />
+        <p>記事が存在しないか削除された可能性があります。</p>
+      </div>
+    );
+  }
+
+  const formattedCreatedDate = new Date(post.createdDate).toLocaleDateString();
+
+  return (
+    <>
+      <div className="blog w-full md:w-3/4 bg-white rounded-sm py-8 px-4 md:px-12 mr-8 ">
+        <Breadcrumbs
+          categoryName={post?.category.name}
+          categorySlug={post?.category.slug}
+        />
+        <h1>{post.title}</h1>
+        <ArticleTop src={post.postImage?.url} alt={post.postImage?.altText} />
+        <p className="text-gray-500 mb-5">
+          記事の投稿日：{formattedCreatedDate}
+        </p>
+        <ArticleContentArea content={post.content} />
+      </div>
+      <div className="w-full md:w-1/4 py-4 bg-white rounded">
+        <SideMenu />
+      </div>
+    </>
+  );
+};
+
+export default Page;

--- a/app/(blog)/[category_slug]/page.tsx
+++ b/app/(blog)/[category_slug]/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+
+import NotFound from "@/app/not-found";
+import Card from "@/app/components/blog/Card";
+import ArticleTop from "@/app/components/blog/blogContent/ArticleTop";
+import Breadcrumbs from "@/app/components/blog/Breadcrumbs";
+import SideMenu from "../../components/blog/SideMenu";
+
+import { getCategory } from "@/app/components/lib/BlogServiceUnique";
+import { getCategories } from "@/app/components/lib/BlogServiceMany";
+
+export async function generateStaticParams() {
+  const categories = await getCategories("categoryAndPostImage");
+
+  return categories.map((category) => ({
+    params: {
+      category_slug: category.slug,
+    },
+    revalidate: 60 * 60 * 24 * 15, 
+  }));
+}
+
+const page = async ({ params }: { params: { category_slug: string } }) => {
+  const category = await getCategory(
+    "slug",
+    params.category_slug,
+    "postsAndPostImage"
+  );
+
+  if (
+    !category ||
+    (!category.title && category.posts.every((post) => !post.draft))
+  ) {
+    return (
+      <div>
+        <NotFound />
+        <p>カテゴリが存在しないか削除された可能性があります。</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="blog w-full md:w-3/4 bg-white rounded-sm py-8 px-4 md:px-12 mr-8 ">
+        <Breadcrumbs
+          categoryName={category?.name}
+          categorySlug={category.slug}
+          isCategoryDirectory={true}
+        />
+        {category?.title ? (
+          <h1>{category?.title}</h1>
+        ) : (
+          <h1>「{category?.name} 」のカテゴリ</h1>
+        )}
+        {category.postImage?.url && (
+          <ArticleTop
+            src={category.postImage?.url}
+            alt={category.postImage?.altText}
+          />
+        )}
+        {category.content && <p>{category.content}</p>}
+        <h2 className="p-2 mt-10 text-3xl">{category?.name}の記事一覧</h2>
+        {category.posts.map((post) => {
+          return (
+            <Link href={`/${category.slug}/${post.slug}`} key={post.id}>
+              <Card post={post} />
+            </Link>
+          );
+        })}
+      </div>
+      <div className="w-full md:w-1/4 py-4 bg-white rounded">
+        <SideMenu />
+      </div>
+    </>
+  );
+};
+
+export default page;

--- a/app/components/blog/Breadcrumbs.tsx
+++ b/app/components/blog/Breadcrumbs.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faHouse, faChevronRight } from "@fortawesome/free-solid-svg-icons";
+
+type BreadcrumbsProps = {
+  categoryName: string;
+  categorySlug: string;
+  isCategoryDirectory?: boolean;
+};
+const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
+  categoryName,
+  categorySlug,
+  isCategoryDirectory,
+}) => {
+  return (
+    <span className="text-sm">
+      <FontAwesomeIcon
+        icon={faHouse}
+        className="w-[14px] h-[14px] inline mb-[2px] mr-4"
+      />
+      <Link href="/">ホーム</Link>
+      <FontAwesomeIcon icon={faChevronRight} className="w-[14px] h-[14px] inline mx-3"/> 
+      {isCategoryDirectory ? (
+        categoryName
+      ) : (
+        <Link href={`/${categorySlug}`}>{categoryName}</Link>
+      )}
+    </span>
+  );
+};
+
+export default Breadcrumbs;

--- a/app/components/blog/Card.tsx
+++ b/app/components/blog/Card.tsx
@@ -1,0 +1,73 @@
+import Image from "next/image";
+
+type Post = {
+  title: string;
+  description: string;
+  draft: boolean;
+  postImage?: {
+    url: string;
+    altText: string;
+  } | null;
+};
+
+type CardProps = {
+  post: Post;
+};
+
+const Card: React.FC<CardProps> = ({ post }) => {
+  return (
+    <>
+      {post.draft && (
+        <div className="flex flex-wrap md:flex-nowrap  border w-full border-gray-400 my-8 hover:bg-gray-100">
+          {post.postImage ? (
+            <div className="w-full md:w-auto pt-3 md:pt-0 min-w-[260px]">
+              <Image
+                src={post.postImage.url}
+                alt={post.postImage.altText}
+                width={260}
+                height={171}
+                style={{
+                  width: "260px",
+                  height: "auto",
+                }}
+                className="block mx-auto"
+              />
+            </div>
+          ) : (
+            <div className="w-full md:w-auto pt-3 md:pt-0 min-w-[260px]">
+              <Image
+                src="/no_image.jpg"
+                alt="画像の準備中"
+                width={328}
+                height={213}
+                style={{
+                  width: "261px",
+                  height: "auto",
+                }}
+                className="block mx-auto"
+              />
+            </div>
+          )}
+          <div className="w-full md:flex-auto px-4 py-3 card">
+            {post.title && post.title.length > 31 ? (
+              <h3 className="text-lg font-bold text-gray-700 mb-4">
+                {post.title.slice(0, 31)}...
+              </h3>
+            ) : (
+              <h3 className="text-lg font-bold text-gray-700 mb-4 border-none ">
+                {post.title}
+              </h3>
+            )}
+            <p className="text-gray-600">
+              {post.description.length > 72
+                ? `${post.description.slice(0, 72)}...`
+                : post.description}
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default Card;

--- a/app/components/blog/SideMenu.tsx
+++ b/app/components/blog/SideMenu.tsx
@@ -1,0 +1,15 @@
+import SideCategoryMenu from "./sideMenu/SideCategoryMenu";
+import SideNewArticles from "./sideMenu/SideNewArticles";
+import SideTop from "./sideMenu/SideTop";
+
+const SideMenu = () => {
+  return (
+    <div className="flex flex-col justify-center items-center bg-white rounded py-2">
+      <SideTop />
+      <SideCategoryMenu />
+      <SideNewArticles />
+    </div>
+  );
+};
+
+export default SideMenu;

--- a/app/components/blog/blogContent/ArticleContentArea.tsx
+++ b/app/components/blog/blogContent/ArticleContentArea.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import parse from "html-react-parser";
+import DOMPurify from "dompurify";
+
+type ArticleContentAreaProps = {
+  content: string;
+};
+
+const ArticleContentArea: React.FC<ArticleContentAreaProps> = ({ content }) => {
+  const [sanitizedContent, setSanitizedContent] = useState("");
+
+  useEffect(() => {
+    const sanitized = DOMPurify.sanitize(content);
+    const formattedContent = sanitized.replace(/\n/g, "<br>");
+    setSanitizedContent(formattedContent);
+  }, [content]);
+
+  return <>{parse(sanitizedContent)}</>;
+};
+export default ArticleContentArea;

--- a/app/components/blog/blogContent/ArticleTop.tsx
+++ b/app/components/blog/blogContent/ArticleTop.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+
+type ArticleTopProps = {
+  src: string | undefined;
+  alt: string | undefined;
+};
+
+const ArticleTop: React.FC<ArticleTopProps> = ({ src, alt }) => {
+  return (
+    <>
+      {src && alt && (
+        <Image
+          src={src}
+          alt={alt}
+          width={650}
+          height={428}
+          priority
+          style={{
+            maxWidth: "100%",
+            height: "auto",
+            aspectRatio: "650 / 428",
+          }}
+          sizes="100vw"
+          className="block mx-auto mb-8 max-w-[650px] max-h-[430px]"
+        />
+      )}
+    </>
+  );
+};
+
+export default ArticleTop;

--- a/app/components/blog/sideMenu/SideCategoryMenu.tsx
+++ b/app/components/blog/sideMenu/SideCategoryMenu.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { getCategories } from "../../lib/BlogServiceMany";
+
+const SideCategoryMenu = async () => {
+  const categories = await getCategories("posts");
+
+  return (
+    <div className="w-full p-2">
+      <h3 className="bg-blue-400 text-white font-bold text-lg px-2 py-4 rounded-sm">
+        カテゴリー
+      </h3>
+      {categories.map((category) => {
+        if (
+          !category ||
+          ((!category.title || category.title === "") &&
+            category.posts.every((post) => !post.draft))
+        ) {
+          return null;
+        }
+        return (
+          <ul key={category.id}>
+            <li className="py-4 hover:bg-gray-200">
+              <Link href={`/${category.slug}`}>
+                <p className="text-gray-600 mb-1 px-3">{category.name}</p>
+              </Link>
+            </li>
+          </ul>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SideCategoryMenu;

--- a/app/components/blog/sideMenu/SideNewArticles.tsx
+++ b/app/components/blog/sideMenu/SideNewArticles.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import Image from "next/image";
+import { getPosts } from "../../lib/BlogServiceMany";
+
+const SideNewArticles = async () => {
+  const posts = await getPosts("categoryAndPostImage", 5,)
+
+  return (
+    <div className="w-full p-2">
+      <h3 className="bg-blue-400 text-white font-bold text-lg px-2 py-4 rounded-sm">
+        新着記事
+      </h3>
+      <ul>
+        {posts.map((post) => {
+          return (
+            post.draft && (
+              <li
+                key={post.id}
+                className="my-6 p-3 border-b border-gray-600 border-dashed hover:bg-gray-200"
+              >
+                <Link href={`/${post.category.slug}/${post.slug}`}>
+                  {post.postImage &&
+                    post.postImage.url &&
+                    post.postImage.altText && (
+                      <Image
+                        src={post.postImage.url}
+                        alt={post.postImage.altText}
+                        width={240}
+                        height={160}
+                        style={{
+                          width: "240px",
+                          height: "auto",
+                          aspectRatio: "240 / 160",
+                        }}
+                        className="block mx-auto max-h-[160px]"
+                      />
+                    )}
+                  {post.title && post.title.length > 36 ? (
+                    <p className="text-gray-600 my-2">
+                      {post.title.slice(0, 36)}...
+                    </p>
+                  ) : (
+                    <p className="text-gray-600 my-2">{post.title}</p>
+                  )}
+                </Link>
+              </li>
+            )
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default SideNewArticles;

--- a/app/components/blog/sideMenu/SideTop.tsx
+++ b/app/components/blog/sideMenu/SideTop.tsx
@@ -1,0 +1,27 @@
+import Image from "next/image";
+import Link from "next/link";
+
+const SideTop = () => {
+  return (
+    <>
+      <div className="hover:bg-gray-200 mb-4">
+        <Link href="/memorybook">
+          <Image
+            src="/travel_memory_thumbnail.jpg"
+            alt="旅のメモリーブックのサムネイル"
+            width={240}
+            height={174}
+            style={{
+              width: "240px",
+              height: "auto",
+            }}
+            className="block mx-auto"
+          />
+          <p className="my-2 text-center">海外旅行のしおりアプリ</p>
+        </Link>
+      </div>
+    </>
+  );
+};
+
+export default SideTop;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@supabase/supabase-js": "^2.42.4",
+        "dompurify": "^3.1.0",
         "framer-motion": "^11.1.7",
+        "html-react-parser": "^5.1.10",
         "next": "14.1.4",
         "next-auth": "^4.24.7",
         "react": "^18",
@@ -26,6 +28,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -684,6 +687,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -707,13 +719,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.74",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.74.tgz",
       "integrity": "sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -727,6 +739,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -1641,6 +1659,62 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.0.tgz",
+      "integrity": "sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA=="
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1670,6 +1744,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -2764,6 +2849,53 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.8.tgz",
+      "integrity": "sha512-vuWiX9EXgu8CJ5m9EP5c7bvBmNSuQVnrY8tl0z0ZX96Uth1IPlYH/8W8VZ/hBajFf18EN+j2pukbCNd01HEd1w==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.1.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.10.tgz",
+      "integrity": "sha512-gV22PvLij4wdEdtrZbGVC7Zy2OVWnQ0bYhX63S196ZRSx4+K0TuutCreHSXr+saUia8KeKB+2TYziVfijpH4Tw==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.0.8",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.12"
+      },
+      "peerDependencies": {
+        "@types/react": "17 || 18",
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -2813,6 +2945,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+      "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -4258,6 +4395,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+    },
     "node_modules/react-textarea-autosize": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
@@ -4804,6 +4946,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.12.tgz",
+      "integrity": "sha512-tv+/FkgNYHI2fvCoBMsqPHh5xovwiw+C3X0Gfnss/Syau0Nr3IqGOJ9XiOYXoPnToHVbllKFf5qCNFJGwFg5mg==",
+      "dependencies": {
+        "style-to-object": "1.0.6"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.6.tgz",
+      "integrity": "sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==",
+      "dependencies": {
+        "inline-style-parser": "0.2.3"
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@supabase/supabase-js": "^2.42.4",
+    "dompurify": "^3.1.0",
     "framer-motion": "^11.1.7",
+    "html-react-parser": "^5.1.10",
     "next": "14.1.4",
     "next-auth": "^4.24.7",
     "react": "^18",
@@ -27,6 +29,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
## ブログの個別記事・カテゴリページ

- [ブログのカテゴリと個別ページの追加](https://github.com/haru0354/next-blog-isr/commit/e141ef5c7e9edb9d3a5d91a82cd4e1b4a4794870)
- [個別記事の表示エリア・サニタライズ](https://github.com/haru0354/next-blog-isr/commit/4a84c3216899df7c93de82233248f02d69acb3fa)
- [個別記事のTOP画像エリアのコンポーネント](https://github.com/haru0354/next-blog-isr/commit/5b4f77b418dfde350c9034ec25ab54b2b1154922)

DOMPurifyとhtml-react-parserを使用して、サニタイズしたコンテンツを表示している。


## その他

- [パンくずリストの追加](https://github.com/haru0354/next-blog-isr/commit/ccde2f966c1d11584430810f4d221fbe86e2a36c)
- [関連記事用のカードの作成](https://github.com/haru0354/next-blog-isr/commit/39b2b129816b835cea8147e12300b283c508f612)

## サイドバー

- [サイドバーのカテゴリ表示](https://github.com/haru0354/next-blog-isr/commit/bd972dc8e7e5df81e508db323167d90ff25adaf0)
- [サイドバーの新着記事の表示](https://github.com/haru0354/next-blog-isr/commit/5dc540a31106efacdf1976e27ec82af653909f4c)
- [サイドバーのCTAエリアの表示](https://github.com/haru0354/next-blog-isr/commit/4edb574f929afb241bbf2ec1a73a92882d13aa9f)





