### PR TITLE
ダッシュボードページの追加(記事・カテゴリ・画像・メモ)

### DIFF
--- a/app/(blog)/dashboard/[memo_id]/page.tsx
+++ b/app/(blog)/dashboard/[memo_id]/page.tsx
@@ -1,0 +1,45 @@
+import { Metadata } from "next";
+import Link from "next/link";
+
+import FormDashboardMemo from "@/app/components/blog/dashboard/FormDashboardMemo";
+import Button from "@/app/components/ui/Button";
+import DeleteModal from "@/app/components/ui/DeleteModal";
+
+import {
+  deleteDashboardMemo,
+  updateDashboardMemo,
+} from "@/app/action/action-dashboard";
+import { getDashboardMemo } from "@/app/components/lib/BlogServiceUnique";
+
+export const metadata: Metadata = {
+  title: "個別のメモ",
+};
+
+const Page = async ({ params }: { params: { memo_id: string } }) => {
+  const id = Number(params.memo_id);
+  const updateDashboardMemoWidthId = updateDashboardMemo.bind(null, id);
+  const dashboardMemo = await getDashboardMemo(params.memo_id)
+
+  return (
+    <>
+      <FormDashboardMemo
+        formAction={updateDashboardMemoWidthId}
+        dashboardMemo={dashboardMemo}
+        buttonName={"保存"}
+      />
+      <Link href="/dashboard/">
+        <Button color="gray" size="normal" className="rounded mt-4">
+          キャンセル
+        </Button>
+      </Link>
+      <DeleteModal
+        DeleteName="メモ"
+        name={dashboardMemo?.name}
+        formAction={deleteDashboardMemo}
+        id={dashboardMemo?.id}
+      />
+    </>
+  );
+};
+
+export default Page;

--- a/app/(blog)/dashboard/category/[category_id]/page.tsx
+++ b/app/(blog)/dashboard/category/[category_id]/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import FormCategory from "@/app/components/blog/dashboard/FormCategory";
+import Button from "@/app/components/ui/Button";
+import DeleteModal from "@/app/components/ui/DeleteModal";
+
+import { updateCategory, deleteCategory } from "@/app/action/action-category";
+import { getCategory } from "@/app/components/lib/BlogServiceUnique";
+
+export const metadata: Metadata = {
+  title: "カテゴリの編集",
+};
+
+const page = async ({ params }: { params: { category_id: string } }) => {
+  const id = Number(params.category_id);
+  const updateCategoryWidthId = updateCategory.bind(null, id);
+
+  const category = await getCategory("id", params.category_id, "postImage");
+
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        カテゴリの編集
+      </h2>
+      <FormCategory
+        formAction={updateCategoryWidthId}
+        category={category}
+        buttonName={"編集内容を保存"}
+      />
+      <Link href="/dashboard/category/">
+        <Button color="gray" size="normal" className="rounded mt-4">
+          キャンセル
+        </Button>
+      </Link>
+      <DeleteModal
+        DeleteName="カテゴリ"
+        name={category?.name}
+        formAction={deleteCategory}
+        id={category?.id}
+      />
+    </>
+  );
+};
+
+export default page;

--- a/app/(blog)/dashboard/category/new-category/page.tsx
+++ b/app/(blog)/dashboard/category/new-category/page.tsx
@@ -1,0 +1,20 @@
+import { addCategory } from "@/app/action/action-category";
+import FormCategory from "@/app/components/blog/dashboard/FormCategory";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "カテゴリの追加",
+};
+
+const page = async () => {
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        カテゴリの追加
+      </h2>
+      <FormCategory buttonName="カテゴリを追加" formAction={addCategory} />
+    </>
+  );
+};
+
+export default page;

--- a/app/(blog)/dashboard/category/page.tsx
+++ b/app/(blog)/dashboard/category/page.tsx
@@ -1,0 +1,16 @@
+import ListCategory from "@/app/components/blog/dashboard/ListCategory";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "カテゴリの一覧",
+};
+
+const page = () => {
+  return (
+    <>
+      <ListCategory />
+    </>
+  );
+};
+
+export default page;

--- a/app/(blog)/dashboard/image/[image_id]/page.tsx
+++ b/app/(blog)/dashboard/image/[image_id]/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+import FormPostImage from "@/app/components/blog/dashboard/FormPostImage";
+import Button from "@/app/components/ui/Button";
+import DeleteModal from "@/app/components/ui/DeleteModal";
+
+import {
+  deletePostImage,
+  updatePostImage,
+} from "@/app/action/action-postImage";
+import { getPostImage } from "@/app/components/lib/BlogServiceUnique";
+
+const page = async ({ params }: { params: { image_id: string } }) => {
+  const id = Number(params.image_id);
+  const updatePostImageWidthId = updatePostImage.bind(null, id);
+  const postImage = await getPostImage(params.image_id)
+
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        画像の編集
+      </h2>
+      <FormPostImage
+        formAction={updatePostImageWidthId}
+        postImage={postImage}
+        buttonName="編集内容を保存"
+      />
+      <Link href="/dashboard/image/">
+        <Button color="gray" size="normal" className="rounded mt-4">
+          キャンセル
+        </Button>
+      </Link>
+      <DeleteModal
+        DeleteName="画像"
+        name={postImage?.name}
+        formAction={deletePostImage}
+        id={postImage?.id}
+      />
+    </>
+  );
+};
+
+export default page;

--- a/app/(blog)/dashboard/image/new-image/page.tsx
+++ b/app/(blog)/dashboard/image/new-image/page.tsx
@@ -1,0 +1,14 @@
+import { addPostImage } from "@/app/action/action-postImage";
+import FormPostImage from "@/app/components/blog/dashboard/FormPostImage";
+
+const page = () => {
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        画像の追加(action)
+      </h2>
+      <FormPostImage buttonName="画像を追加" formAction={addPostImage} />
+    </>
+  );
+};
+export default page;

--- a/app/(blog)/dashboard/image/page.tsx
+++ b/app/(blog)/dashboard/image/page.tsx
@@ -1,0 +1,14 @@
+import ListImages from "@/app/components/blog/dashboard/ListImages";
+
+const page = () => {
+  return (
+    <div>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        画像ライブラリー
+      </h2>
+      <ListImages />
+    </div>
+  );
+};
+
+export default page;

--- a/app/(blog)/dashboard/page.tsx
+++ b/app/(blog)/dashboard/page.tsx
@@ -1,0 +1,14 @@
+import { addDashboardMemo } from "@/app/action/action-dashboard";
+import FormDashboardMemo from "@/app/components/blog/dashboard/FormDashboardMemo";
+import ListDashboardMemo from "@/app/components/blog/dashboard/ListDashboardMemo";
+
+const Memo = async () => {
+  return (
+    <>
+      <ListDashboardMemo />
+      <FormDashboardMemo formAction={addDashboardMemo} buttonName="追加" />
+    </>
+  );
+};
+
+export default Memo;

--- a/app/(blog)/dashboard/post/[post_id]/page.tsx
+++ b/app/(blog)/dashboard/post/[post_id]/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+import FormPost from "@/app/components/blog/dashboard/FormPost";
+import DeleteModal from "@/app/components/ui/DeleteModal";
+import Button from "@/app/components/ui/Button";
+
+import { deletePost, updatePost } from "@/app/action/action-post";
+import { getPost } from "@/app/components/lib/BlogServiceUnique";
+import { getCategories } from "@/app/components/lib/BlogServiceMany";
+
+const page = async ({ params }: { params: { post_id: string } }) => {
+  const id = Number(params.post_id);
+  const updatePostWidthId = updatePost.bind(null, id);
+  const post = await getPost("id", params.post_id, "categoryAndPostImage")
+  const categories = await getCategories()
+
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        記事の編集
+      </h2>
+      <FormPost
+        formAction={updatePostWidthId}
+        post={post}
+        categories={categories}
+        buttonName={"編集内容を保存"}
+      />
+      <Link href="/dashboard/post/">
+        <Button color="gray" size="normal" className="rounded mt-4">
+          キャンセル
+        </Button>
+      </Link>
+      <DeleteModal
+        DeleteName="記事"
+        name={post?.title}
+        formAction={deletePost}
+        id={post?.id}
+      />
+    </>
+  );
+};
+
+export default page;

--- a/app/(blog)/dashboard/post/new-post/page.tsx
+++ b/app/(blog)/dashboard/post/new-post/page.tsx
@@ -1,0 +1,23 @@
+import { addPost } from "@/app/action/action-post";
+
+import FormPost from "@/app/components/blog/dashboard/FormPost";
+import { getCategories } from "@/app/components/lib/BlogServiceMany";
+
+const page = async () => {
+  const categories = await getCategories()
+  
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        記事の追加
+      </h2>
+      <FormPost
+        buttonName="記事を追加"
+        formAction={addPost}
+        categories={categories}
+      />
+    </>
+  );
+};
+
+export default page;

--- a/app/(blog)/dashboard/post/page.tsx
+++ b/app/(blog)/dashboard/post/page.tsx
@@ -1,0 +1,11 @@
+import ListPost from "@/app/components/blog/dashboard/ListPost";
+
+const page = async () => {
+  return (
+    <>
+      <ListPost />
+    </>
+  );
+};
+
+export default page;

--- a/app/components/blog/dashboard/DashboardSideMenu.tsx
+++ b/app/components/blog/dashboard/DashboardSideMenu.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import Link from "next/link";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faList,
+  faPen,
+  faImage,
+  faHouse,
+  faBars,
+  faXmark,
+} from "@fortawesome/free-solid-svg-icons";
+import { useState } from "react";
+import { signOut } from "next-auth/react";
+import Button from "../../ui/Button";
+
+const DashboardSideMenu = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleLogout = async () => {
+    await signOut({ callbackUrl: "/admin" });
+  };
+
+  return (
+    <>
+      <div className="hidden sm:block fixed top-0 left-0 h-screen w-72 flex-col sm:flex-row sm:justify-around bg-gray-700">
+        <nav className="px-6 mt-10 w-full">
+          <div className="mb-6">
+            <h3 className="w-full pb-2 mb-2 border-b-2 border-gray-300 text-white text-lg">
+              ダッシュボード
+            </h3>
+            <ul>
+              <Link href="/">
+                <li className="flex py-3 px-2 text-white duration-300 hover:text-gray-900 hover:bg-gray-300 ">
+                  <FontAwesomeIcon
+                    icon={faHouse}
+                    className="mr-2 w-5 h-4 mt-1"
+                  />
+                  ブログTOP
+                </li>
+              </Link>
+              <Link href="/dashboard">
+                <li className="flex py-3 px-2 text-white duration-300 hover:text-gray-900 hover:bg-gray-300 ">
+                  <FontAwesomeIcon
+                    icon={faHouse}
+                    className="mr-2 w-5 h-4 mt-1"
+                  />
+                  サイト制作のメモ
+                </li>
+              </Link>
+            </ul>
+          </div>
+          <div className="mb-6">
+            <h3 className="w-full pb-2 mb-2 border-b-2 border-gray-300 text-white text-lg">
+              記事
+            </h3>
+            <ul>
+              <Link href="/dashboard/post">
+                <li className="flex py-3 px-2 text-white duration-300 hover:text-gray-900 hover:bg-gray-300 ">
+                  <FontAwesomeIcon icon={faPen} className="mr-2 w-5 h-4 mt-1" />
+                  記事一覧
+                </li>
+              </Link>
+              <Link href="/dashboard/post/new-post">
+                <li className="flex py-3 px-2 text-white duration-300 hover:text-gray-900 hover:bg-gray-300 ">
+                  <FontAwesomeIcon icon={faPen} className="mr-2 w-5 h-4 mt-1" />
+                  新規記事
+                </li>
+              </Link>
+            </ul>
+          </div>
+          <div className="mb-6">
+            <h3 className="w-full pb-2 mb-2 border-b-2 border-gray-300 text-white text-lg">
+              カテゴリー
+            </h3>
+            <ul>
+              <Link href="/dashboard/category">
+                <li className="flex py-3 px-2 text-white duration-300 hover:text-gray-900 hover:bg-gray-300 ">
+                  <FontAwesomeIcon
+                    icon={faList}
+                    className="mr-2 w-5 h-4 mt-1"
+                  />
+                  カテゴリー一覧
+                </li>
+              </Link>
+              <Link href="/dashboard/category/new-category">
+                <li className="flex py-3 px-2 text-white duration-300 hover:text-gray-900 hover:bg-gray-300 ">
+                  <FontAwesomeIcon
+                    icon={faList}
+                    className="mr-2 w-5 h-4 mt-1"
+                  />
+                  新規カテゴリー
+                </li>
+              </Link>
+            </ul>
+          </div>
+          <div className="mb-6">
+            <h3 className="w-full pb-2 mb-2 border-b-2 border-gray-300 text-white text-lg">
+              画像
+            </h3>
+            <ul>
+              <Link href="/dashboard/image">
+                <li className="flex py-3 px-2 text-white duration-300 hover:text-gray-900 hover:bg-gray-300 ">
+                  <FontAwesomeIcon
+                    icon={faImage}
+                    className="mr-2 w-5 h-4 mt-1"
+                  />
+                  画像一覧
+                </li>
+              </Link>
+              <Link href="/dashboard/image/new-image">
+                <li className="flex py-3 px-2 text-white duration-300 hover:text-gray-900 hover:bg-gray-300 ">
+                  <FontAwesomeIcon
+                    icon={faImage}
+                    className="mr-2 w-5 h-4 mt-1"
+                  />
+                  新規画像
+                </li>
+              </Link>
+            </ul>
+          </div>
+          <Button
+            onClick={handleLogout}
+            color="white"
+            size="normal"
+            className="rounded mt-4"
+          >
+            ログアウト
+          </Button>
+        </nav>
+      </div>
+      {/* ハンバーガーメニュー */}
+      <div>
+        <button
+          className="block sm:hidden text-white p-2 w-12 h-12 border rounded bg-gray-700 border-gray-800 fixed"
+          onClick={toggleMenu}
+        >
+          <FontAwesomeIcon
+            icon={faBars}
+            style={{ width: "14px", height: "16px" }}
+          />
+        </button>
+        {isOpen && (
+          <>
+            <button
+              className="block sm:hidden text-white p-2 w-12 h-12 border rounded bg-gray-700 border-gray-800 fixed z-10"
+              onClick={toggleMenu}
+            >
+              <FontAwesomeIcon
+                icon={faXmark}
+                style={{ width: "14px", height: "16px" }}
+              />
+            </button>
+            <div className="fixed top-0 left-0 w-full h-screen bg-gray-500 px-10 pt-12">
+              <ul className="text-white" onClick={toggleMenu}>
+                <li className="py-2 border-b">ダッシュボード</li>
+                <Link href="/">
+                  <li className="py-2 mx-4 hover:bg-gray-300 hover:text-gray-900">
+                    ブログTOP
+                  </li>
+                </Link>
+                <Link href="/dashboard">
+                  <li className="py-2 mx-4 hover:bg-gray-300 hover:text-gray-900">
+                    サイト制作のメモ
+                  </li>
+                </Link>
+                <li className="py-2 border-b mt-3">記事</li>
+                <Link href="/dashboard/post">
+                  <li className="py-2 mx-4 hover:bg-gray-300 hover:text-gray-900">
+                    記事一覧
+                  </li>
+                </Link>
+                <Link href="/dashboard/post/new-post">
+                  <li className="py-2 mx-4 hover:bg-gray-300 hover:text-gray-900">
+                    新規記事
+                  </li>
+                </Link>
+                <li className="py-2 mt-3 border-b">カテゴリー</li>
+                <Link href="/dashboard/category">
+                  <li className="py-2 mx-4 hover:bg-gray-300 hover:text-gray-900">
+                    カテゴリー一覧
+                  </li>
+                </Link>
+                <Link href="/dashboard/category/new-category">
+                  <li className="py-2 mx-4 hover:bg-gray-300 hover:text-gray-900">
+                    カテゴリー追加
+                  </li>
+                </Link>
+                <li className="py-2 mt-3 border-b">画像</li>
+                <Link href="/dashboard/image">
+                  <li className="py-2 mx-4 hover:bg-gray-300 hover:text-gray-900">
+                    画像一覧
+                  </li>
+                </Link>
+                <Link href="/dashboard/image/new-image">
+                  <li className="py-2 mx-4 hover:bg-gray-300 hover:text-gray-900">
+                    画像追加
+                  </li>
+                </Link>
+              </ul>
+              <Button
+                onClick={handleLogout}
+                color="white"
+                size="normal"
+                className="rounded mt-4"
+              >
+                ログアウト
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default DashboardSideMenu;

--- a/app/components/blog/dashboard/FormCategory.tsx
+++ b/app/components/blog/dashboard/FormCategory.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import Form from "../../ui/Form";
+import Button from "../../ui/Button";
+import TextArea from "../../ui/TextArea";
+import FormImage from "../../ui/FormImage";
+import { useFormState } from "react-dom";
+
+type FormCategoryProps = {
+  category?: (Category & { postImage: PostImage | null }) | null;
+  buttonName: string;
+  formAction: (state: FormState, data: FormData) => Promise<FormState>;
+};
+
+type Category = {
+  name: string;
+  slug: string;
+  content: string | null;
+  description: string | null;
+  title: string | null;
+};
+
+type PostImage = {
+  id: number;
+  altText: string;
+  name: string;
+  url: string;
+};
+
+type FormState = {
+  message?: string | null;
+  errors?: {
+    name?: string[] | undefined;
+    slug?: string[] | undefined;
+    image?: string[] | undefined;
+    altText?: string[] | undefined;
+  };
+};
+
+const FormCategory: React.FC<FormCategoryProps> = ({
+  category,
+  buttonName,
+  formAction,
+}) => {
+  const initialState = {
+    message: null,
+    errors: { name: undefined, slug: undefined, altText: undefined },
+  };
+  const [state, dispatch] = useFormState<FormState, FormData>(
+    formAction,
+    initialState
+  );
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    dispatch(formData);
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-center">
+        <div className="w-full border py-4 px-6  border-gray-300 rounded bg-white max-w-full">
+          <form onSubmit={handleSubmit}>
+            {state.message && <p className="text-red-500">{state.message}</p>}
+            <Form
+              name={"name"}
+              label={"カテゴリ名"}
+              placeholder={"カテゴリ名を入力してください。"}
+              defaultValue={category?.name}
+            />
+            {state.errors && (
+              <p className="text-red-500">{state.errors.name}</p>
+            )}
+            <Form
+              name={"slug"}
+              label={"スラッグ"}
+              placeholder={
+                "カテゴリのスラッグを半角小文字の英数字で入力してください。"
+              }
+              defaultValue={category?.slug}
+            />
+            {state.errors && (
+              <p className="text-red-500">{state.errors.slug}</p>
+            )}
+            <TextArea
+              name={"description"}
+              label={"カテゴリの説明(description)"}
+              placeholder={
+                "カテゴリの説明(description)を入力してください。この項目は必須ではありません。"
+              }
+              defaultValue={category?.description ?? ""}
+            />
+            <p className="border-b my-5 pb-2 font-semibold">
+              カテゴリを記事にする(カテゴリにコンテンツを表示)
+            </p>
+            <TextArea
+              name={"title"}
+              label={"カテゴリのタイトル"}
+              placeholder={
+                "カテゴリのタイトルを入力してください。カテゴリページにタイトルが表示されます。この項目は必須ではありません。"
+              }
+              defaultValue={category?.title || undefined}
+            />
+            <TextArea
+              name={"content"}
+              label={"カテゴリの内容"}
+              placeholder={
+                "カテゴリの内容を入力してください。カテゴリページに表示がされます。この項目は必須ではありません。"
+              }
+              defaultValue={category?.content || undefined}
+            />
+            <FormImage
+              selectImage={category?.postImage}
+              state={state}
+              label="画像の名前(alt)"
+              placeholder="どんな画像か入力してください。検索エンジンが画像を認識するのに役立ちます"
+            />
+            <Button color="blue" size="normal" className="rounded mt-4">
+              {buttonName}
+            </Button>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FormCategory;

--- a/app/components/blog/dashboard/FormDashboardMemo.tsx
+++ b/app/components/blog/dashboard/FormDashboardMemo.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, ChangeEvent } from "react";
+import Button from "../../ui/Button";
+import Form from "../../ui/Form";
+import TextArea from "../../ui/TextArea";
+import toast from "react-hot-toast";
+import { useFormState } from "react-dom";
+import { useRouter } from "next/navigation";
+
+type FormMemoProps = {
+  dashboardMemo?: DashboardMemo | null;
+  buttonName: string;
+  formAction: (state: FormState, data: FormData) => Promise<FormState>;
+};
+
+type DashboardMemo = {
+  id: number;
+  name: string;
+  content: string;
+};
+
+type FormState = {
+  message?: string | null;
+  errors?: {
+    name?: string[] | undefined;
+    content?: string[] | undefined;
+  };
+};
+
+const FormDashboardMemo: React.FC<FormMemoProps> = ({
+  dashboardMemo,
+  buttonName,
+  formAction,
+}) => {
+  const router = useRouter();
+  const initialState = { message: null, errors: { name: undefined } };
+  const [state, dispatch] = useFormState<FormState, FormData>(
+    formAction,
+    initialState
+  );
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  const [inputValue, setInputValue] = useState<string>(
+    dashboardMemo?.name || ""
+  );
+  const [textAreaValue, setTextareaChange] = useState<string>(
+    dashboardMemo?.content || ""
+  );
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  const handleTextareaChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setTextareaChange(e.target.value);
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const result = await formAction(state, formData);
+    if ("message" in result) {
+      if (result.message === "add") {
+        setInputValue("");
+        setTextareaChange("");
+        toast.success("メモを保存しました！");
+      } else if (result.message === "edit") {
+        toast.success("メモを編集しました！");
+        router.replace("/dashboard");
+      } else if (result.message === "failure") {
+        if (result.errors && result.errors.name) {
+          setErrorMessage(result.errors.name[0]);
+        }
+      }
+    }
+  };
+
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        メモの追加
+      </h2>
+      <div className="flex items-center justify-center">
+        <div className="w-full border py-4 px-6  border-gray-300 rounded bg-white max-w-full">
+          <form action={dispatch} onSubmit={handleSubmit}>
+            <Form
+              label={"メモの見出し"}
+              name={"name"}
+              placeholder="メモの見出しを記載しましょう。"
+              value={inputValue}
+              onChange={handleInputChange}
+            />
+            {errorMessage && <p className="text-red-500">{errorMessage}</p>}
+            <TextArea
+              label={"メモする内容"}
+              name={"content"}
+              placeholder="メモする内容を記載しましょう。"
+              value={textAreaValue}
+              onChange={handleTextareaChange}
+            />
+            <Button color="blue" size="normal" className="rounded mt-4">
+              {buttonName}
+            </Button>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FormDashboardMemo;

--- a/app/components/blog/dashboard/FormPost.tsx
+++ b/app/components/blog/dashboard/FormPost.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import TextArea from "@/app/components/ui/TextArea";
+import Form from "@/app/components/ui/Form";
+import Button from "@/app/components/ui/Button";
+import Select from "../../ui/Select";
+import { useFormState } from "react-dom";
+import FormImage from "../../ui/FormImage";
+import DOMPurify from "dompurify";
+import Checkbox from "../../ui/Checkbox";
+import { useState } from "react";
+
+type FormPostProps = {
+  post?: (Post & { category: Category; postImage: PostImage | null }) | null;
+  categories?: Category[] | null;
+  formAction: (state: FormState, data: FormData) => Promise<FormState>;
+  buttonName: string;
+};
+
+type Category = {
+  id: number;
+  name: string;
+};
+
+type PostImage = {
+  id: number;
+  altText: string;
+  name: string;
+  url: string;
+};
+
+type Post = {
+  id: number;
+  title: string;
+  content: string;
+  slug: string;
+  description: string;
+  draft: boolean;
+};
+
+type FormState = {
+  message?: string | null;
+  errors?: {
+    title?: string[] | undefined;
+    content?: string[] | undefined;
+    slug?: string[] | undefined;
+    description?: string[] | undefined;
+    image?: string[] | undefined;
+    altText?: string[] | undefined;
+  };
+};
+
+const FormPost: React.FC<FormPostProps> = ({
+  post,
+  categories,
+  formAction,
+  buttonName,
+}) => {
+  const initialState = {
+    message: null,
+    errors: {
+      title: undefined,
+      categoryId: undefined,
+      slug: undefined,
+      content: undefined,
+      description: undefined,
+      altText: undefined,
+    },
+  };
+  const category = post?.category;
+
+  const [state, dispatch] = useFormState<FormState, FormData>(
+    formAction,
+    initialState
+  );
+  const [isDraft, setIsDraft] = useState<boolean>(post?.draft ?? false); 
+
+  const handleToggle = () => {
+    setIsDraft(!isDraft); 
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+
+    const sanitizedFormData = new FormData();
+    for (const [key, value] of formData.entries()) {
+      let sanitizedValue = value;
+      if (key !== "image") {
+        sanitizedValue = DOMPurify.sanitize(value.toString());
+      }
+      sanitizedFormData.append(key, sanitizedValue);
+    }
+    sanitizedFormData.set("draft", isDraft.toString());
+
+    dispatch(sanitizedFormData);
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-center">
+        <div className="w-full border py-4 px-6  border-gray-300 rounded bg-white max-w-full">
+          <form onSubmit={handleSubmit}>
+            <Form
+              name="title"
+              label="記事のタイトル"
+              defaultValue={post?.title}
+              placeholder="記事のタイトルを31文字を目安に入力してください。"
+            />
+            {state.errors && state.errors.title && (
+              <p className="text-red-500">{state.errors.title}</p>
+            )}
+            <Select
+              label="カテゴリ"
+              name="categoryId"
+              categories={categories}
+              defaultValue={category?.id}
+            />
+            <Form
+              name="slug"
+              label="スラッグ"
+              defaultValue={post?.slug}
+              placeholder="記事のスラッグを入力してください。"
+            />
+            {state.errors && state.errors.slug && (
+              <p className="text-red-500">{state.errors.slug}</p>
+            )}
+            <TextArea
+              name="content"
+              label="記事の内容"
+              defaultValue={post?.content}
+              placeholder="記事の内容をこちらに入力してください。"
+            />
+            {state.errors && state.errors.content && (
+              <p className="text-red-500">{state.errors.content}</p>
+            )}
+            <TextArea
+              name="description"
+              label="記事の説明(description)"
+              defaultValue={post?.description}
+              placeholder="120文字を目安に記入してください。"
+            />
+            {state.errors && state.errors.description && (
+              <p className="text-red-500">{state.errors.description}</p>
+            )}
+            <FormImage
+              selectImage={post?.postImage}
+              state={state}
+              label="画像の名前(alt)"
+              placeholder="どんな画像か入力してください。検索エンジンが画像を認識するのに役立ちます"
+            />
+            <Checkbox
+              checked={isDraft}
+              name="draft"
+              item="公開(未選択状態は下書き保存されます)"
+              label="記事の公開設定"
+              onChange={handleToggle}
+            />
+            <Button color="blue" size="normal" className="rounded mt-4">
+              {buttonName}
+            </Button>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FormPost;

--- a/app/components/blog/dashboard/FormPostImage.tsx
+++ b/app/components/blog/dashboard/FormPostImage.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Button from "../../ui/Button";
+import { useFormState } from "react-dom";
+import FormImage from "../../ui/FormImage";
+
+type FormPostImageProps = {
+  postImage?: PostImage | null;
+  buttonName: string;
+  formAction: (state: FormState, data: FormData) => Promise<FormState>;
+};
+
+type PostImage = {
+  url: string;
+  altText: string;
+};
+
+type FormState = {
+  message?: string | null;
+  errors?: {
+    image?: string[] | undefined;
+    altText?: string[] | undefined;
+  };
+};
+
+const FormPostImage: React.FC<FormPostImageProps> = ({
+  postImage,
+  buttonName,
+  formAction,
+}) => {
+  const initialState = {
+    message: null,
+    errors: { image: undefined, altText: undefined },
+  };
+  const [state, dispatch] = useFormState<FormState, FormData>(
+    formAction,
+    initialState
+  );
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    dispatch(data);
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-center">
+        <div className="w-full border py-4 px-6  border-gray-300 rounded bg-white max-w-full">
+          <form onSubmit={handleSubmit}>
+            <FormImage
+              selectImage={postImage}
+              state={state}
+              label="画像の名前(alt)"
+              placeholder="どんな画像か入力してください。検索エンジンが画像を認識するのに役立ちます"
+            />
+            <Button color="blue" size="normal" className="rounded mt-4">
+              {buttonName}
+            </Button>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FormPostImage;

--- a/app/components/blog/dashboard/ListCategory.tsx
+++ b/app/components/blog/dashboard/ListCategory.tsx
@@ -1,0 +1,70 @@
+import Button from "../../ui/Button";
+import Link from "next/link";
+import { getCategories } from "../../lib/BlogServiceMany";
+
+const ListCategory = async () => {
+  const categories = await getCategories();
+
+  const sortedCategories = categories.sort((a, b) => a.id - b.id);
+
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        カテゴリの一覧
+      </h2>
+      <div className="flex flex-col border border-gray-500 sm:flex-row py-4 items-center w-full sm:w-auto">
+        <p className="sm:border-r border-gray-500  w-full mb-0 px-2 sm:w-auto min-w-[180px]">
+          カテゴリ名
+        </p>
+        <p className="sm:border-r flex-wrap  w-full border-gray-500 mb-0 px-2 sm:w-auto min-w-[160px]">
+          スラッグ
+        </p>
+        <p className=" flex-wrap  w-full border-gray-500 mb-0 px-2 sm:w-auto  min-w-[250px] max-w-[650px]">
+          説明文
+        </p>
+      </div>
+      <div className="mb-10">
+        {sortedCategories.map((category) => {
+          return (
+            <div
+              key={category.id}
+              className="flex justify-between flex-col sm:flex-row border-b border-gray-500 w-full"
+            >
+              <div className="flex flex-col  sm:flex-row py-4 items-center w-full sm:w-auto">
+                <p className="sm:border-r border-gray-500  w-full mb-0 px-2 sm:w-auto min-w-[180px]">
+                  {category.name.length > 9
+                    ? `${category.name.slice(0, 9)}...`
+                    : category.name}
+                </p>
+                <p className="sm:border-r flex-wrap  w-full border-gray-500 mb-0 px-2 sm:w-auto min-w-[160px]">
+                  {category.slug.length > 14
+                    ? `${category.slug.slice(0, 14)}...`
+                    : category.slug}
+                </p>
+                <p className="mb-0 px-2 w-full sm:w-auto min-w-[250px] max-w-[560px]">
+                  {category.description && category.description.length > 33
+                    ? `${category.description.slice(0, 33)}...`
+                    : category.description}
+                </p>
+              </div>
+              <div className="flex sm:justify-end items-center my-4 sm:max-w-[240px]">
+                <Link href={`/${category.slug}`}>
+                  <Button color="blue" size="small">
+                    ページ
+                  </Button>
+                </Link>
+                <Link href={`/dashboard/category/${category.id}`}>
+                  <Button color="gray" size="small">
+                    編集
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+};
+
+export default ListCategory;

--- a/app/components/blog/dashboard/ListDashboardMemo.tsx
+++ b/app/components/blog/dashboard/ListDashboardMemo.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPenToSquare } from "@fortawesome/free-regular-svg-icons";
+
+import ButtonImage from "../../ui/ButtonImage";
+import React from "react";
+import { getDashboardMemos } from "../../lib/BlogServiceMany";
+
+const ListDashboardMemo = async () => {
+  const dashboardMemos = await getDashboardMemos();
+
+  const sortedDashboardMemos = dashboardMemos.sort((a, b) => a.id - b.id);
+
+  if (sortedDashboardMemos.length === 0) {
+    return (
+      <>
+        <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+          メモの使い方
+        </h2>
+        <p>ここではサイト制作時のメモが簡単に追加できます。</p>
+        <ul className="my-6 px-4 border p-4">
+          <li className="flex py-3 px-2 text-red-500  ">
+            <FontAwesomeIcon
+              icon={faPenToSquare}
+              className="text-sky-700 mr-4 w-5 h-4 mt-1"
+              style={{ width: "15px" }}
+            />
+            今後作成予定のページ
+          </li>
+          <li className="flex py-3 px-2 text-red-500  ">
+            <FontAwesomeIcon
+              icon={faPenToSquare}
+              className="text-sky-700 mr-4 w-5 h-4 mt-1"
+              style={{ width: "15px" }}
+            />
+            上位表示を狙っているキーワード
+          </li>
+          <li className="flex py-3 px-2 text-red-500  ">
+            <FontAwesomeIcon
+              icon={faPenToSquare}
+              className="text-sky-700 mr-4 w-5 h-4 mt-1"
+              style={{ width: "15px" }}
+            />
+            上位表示させる為に編集をする予定のページ
+          </li>
+        </ul>
+        <p>
+          元々ブログ制作時にこんな機能があったら嬉しいと思ったので追加しました。
+        </p>
+        <p>
+          様々なメモを登録できるのでご自由にあなたにあった使い方をしてください。
+        </p>
+        <p className="pb-6"></p>
+        例）
+        <div className="bg-gray-100 shadow-md rounded px-8 py-8 mb-10 border border-gray-200">
+          <div className="flex justify-between border-b border-gray-500 mb-2">
+            <div>
+              <p className="text-red-500">メモの見出しエリア</p>
+              今後作成していく記事のメインキーワード
+            </div>
+          </div>
+          <div>
+            <p className="text-red-500">メモする内容エリア</p>
+          
+              「ブログ 作り方 無料」・「ブログ 作り方」・「スマホ・ブログ
+              始め方」・「初心者 スマホ ブログ 作り方 」・「趣味・ブログ
+              始め方」・「無料 ブログ 始め方 」・「ブログ 初心者 おすすめ無料」
+            
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        メモの一覧
+      </h2>
+      {sortedDashboardMemos.map((memo) => {
+        return (
+          <React.Fragment key={memo.id}>
+            <Link href={`/dashboard/${memo.id}`}>
+              <ButtonImage
+                className="rounded"
+                size="small"
+                icon="pen"
+                iconClassName="mr-2 w-[13px] h-[13px]"
+              >
+                編集
+              </ButtonImage>
+            </Link>
+            <div className="bg-gray-200 shadow-md rounded px-8 py-8 mb-10 ">
+              <div className="flex justify-between border-b-2 border-gray-300 mb-2">
+                <div>{memo.name}</div>
+              </div>
+              <div>{memo.content}</div>
+            </div>
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+};
+
+export default ListDashboardMemo;

--- a/app/components/blog/dashboard/ListImages.tsx
+++ b/app/components/blog/dashboard/ListImages.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { getPostImages } from "../../lib/BlogServiceMany";
+
+const ListImages = async () => {
+  const images = await getPostImages();
+  
+  const sortedImages = images.sort((a,b) => b.id - a.id)
+
+  return (
+    <div className="flex flex-wrap w-full">
+      {sortedImages.map((image) => {
+        return (
+          <Link href={`/dashboard/image/${image.id}`} key={image.id}>
+            <div className="mx-4 my-4">
+              <Image
+                src={image.url}
+                alt={image.altText}
+                width={210}
+                height={100}
+                style={{
+                  width: "240px",
+                  height: "160px",
+                }}
+              />
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ListImages;

--- a/app/components/blog/dashboard/ListPost.tsx
+++ b/app/components/blog/dashboard/ListPost.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+
+import Button from "../../ui/Button";
+import { getPosts } from "../../lib/BlogServiceMany";
+
+const ListPost = async () => {
+  const posts = await getPosts("category");
+
+  const sortedPosts = posts.sort((a, b) => b.id - a.id);
+
+  return (
+    <>
+      <h2 className="bg-gray-700 text-xl bold text-white rounded mb-12 p-5 font-bold">
+        記事の一覧
+      </h2>
+      <div className="flex flex-col border border-gray-500 sm:flex-row py-4 items-center w-full sm:w-auto">
+        <p className="sm:border-r border-gray-500  w-full px-2 mb-0 sm:w-auto min-w-[100px]">
+          投稿日
+        </p>
+        <p className="sm:border-r flex-wrap  w-full border-gray-500 mb-0 px-2  sm:w-auto min-w-[174px]">
+          カテゴリ
+        </p>
+        <p className=" flex-wrap  w-full border-gray-500 mb-0 px-2 sm:w-auto  min-w-[250px] max-w-[650px]">
+          タイトル
+        </p>
+      </div>
+      <div className="mb-10">
+        {sortedPosts.map((post) => {
+          const formattedCreatedDate = new Date(
+            post.createdDate
+          ).toLocaleDateString();
+          return (
+            <div
+              key={post.id}
+              className="flex justify-between flex-col sm:flex-row border-b border-gray-500 w-full"
+            >
+              <div className="flex flex-col  sm:flex-row py-4 items-center w-full sm:w-auto">
+                <p className="sm:border-r border-gray-500  w-full mb-0 px-2 sm:w-auto min-w-[100px]">
+                  {formattedCreatedDate}
+                </p>
+                <p className="sm:border-r flex-wrap  w-full border-gray-500 mb-0 px-2 sm:w-auto min-w-[174px]">
+                  {post.category.name.length > 9
+                    ? `${post.category.name.slice(0, 9)}...`
+                    : post.category.name}
+                </p>
+                <p className="mb-0 px-2 w-full sm:w-auto min-w-[250px] max-w-[650px]">
+                  {post.title && post.title.length > 33
+                    ? `${post.title.slice(0, 33)}...`
+                    : post.title}
+                </p>
+              </div>
+              <div className="flex sm:justify-end items-center my-4 sm:max-w-[240px]">
+                <Link href={`/${post.category.slug}/${post.slug}`}>
+                  <Button color="blue" size="small">
+                    ページ
+                  </Button>
+                </Link>
+                <Link href={`/dashboard/post/${post.id}`}>
+                  <Button color="gray" size="small">
+                    編集
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+};
+
+export default ListPost;


### PR DESCRIPTION
- [ダッシュボードページの追加](https://github.com/haru0354/next-blog-isr/commit/f06a8ef8f41e156c490b26aa6bc5d84caa7b36ba)
- [ダッシュボードのカテゴリページの作成](https://github.com/haru0354/next-blog-isr/commit/1d278369610cff01e8036acb02b4db1ff9af692a)
- [ダッシュボードの画像ライブラリの追加・削除・編集](https://github.com/haru0354/next-blog-isr/commit/0c89546bb72a9a10d3f8c3160c20a08cb9967b26)
- [投稿ページの追加・削除・編集ページの作成](https://github.com/haru0354/next-blog-isr/commit/b200cbc78f194521ec1bb9f167a7996a6d727be8)
- [ダッシュボードのサイドメニューの作成](https://github.com/haru0354/next-blog-isr/commit/730899bf5f19e47be3204ee62189af77adb69c16)

各種ダッシュボードページの追加。
それぞれ、追加・削除・編集が可能になっている。

