### PR TITLE
目次の作成(cheeiroを使用して自動で目次が作成される)

### DIFF
--- a/app/(blog)/[category_slug]/[post_slug]/page.tsx
+++ b/app/(blog)/[category_slug]/[post_slug]/page.tsx
@@ -6,6 +6,7 @@ import SideMenu from "@/app/components/blog/SideMenu";
 
 import { getPost } from "@/app/components/lib/BlogServiceUnique";
 import { getPosts } from "@/app/components/lib/BlogServiceMany";
+import TableOfContents from "@/app/components/blog/TableOfContents";
 
 export async function generateStaticParams() {
   const posts = await getPosts("categoryAndPostImage");
@@ -44,6 +45,7 @@ const Page = async ({ params }: { params: { post_slug: string } }) => {
         <p className="text-gray-500 mb-5">
           記事の投稿日：{formattedCreatedDate}
         </p>
+        <TableOfContents content={post.content}/>
         <ArticleContentArea content={post.content} />
       </div>
       <div className="w-full md:w-1/4 py-4 bg-white rounded">

--- a/app/(blog)/[category_slug]/[post_slug]/page.tsx
+++ b/app/(blog)/[category_slug]/[post_slug]/page.tsx
@@ -6,7 +6,6 @@ import SideMenu from "@/app/components/blog/SideMenu";
 
 import { getPost } from "@/app/components/lib/BlogServiceUnique";
 import { getPosts } from "@/app/components/lib/BlogServiceMany";
-import TableOfContents from "@/app/components/blog/TableOfContents";
 
 export async function generateStaticParams() {
   const posts = await getPosts("categoryAndPostImage");
@@ -45,7 +44,6 @@ const Page = async ({ params }: { params: { post_slug: string } }) => {
         <p className="text-gray-500 mb-5">
           記事の投稿日：{formattedCreatedDate}
         </p>
-        <TableOfContents content={post.content}/>
         <ArticleContentArea content={post.content} />
       </div>
       <div className="w-full md:w-1/4 py-4 bg-white rounded">

--- a/app/(blog)/[category_slug]/page.tsx
+++ b/app/(blog)/[category_slug]/page.tsx
@@ -8,6 +8,7 @@ import SideMenu from "../../components/blog/SideMenu";
 
 import { getCategory } from "@/app/components/lib/BlogServiceUnique";
 import { getCategories } from "@/app/components/lib/BlogServiceMany";
+import ArticleContentArea from "@/app/components/blog/blogContent/ArticleContentArea";
 
 export async function generateStaticParams() {
   const categories = await getCategories("categoryAndPostImage");
@@ -16,7 +17,7 @@ export async function generateStaticParams() {
     params: {
       category_slug: category.slug,
     },
-    revalidate: 60 * 60 * 24 * 15, 
+    revalidate: 60 * 60 * 24 * 15,
   }));
 }
 
@@ -58,7 +59,7 @@ const page = async ({ params }: { params: { category_slug: string } }) => {
             alt={category.postImage?.altText}
           />
         )}
-        {category.content && <p>{category.content}</p>}
+        {category.content && <ArticleContentArea content={category.content} />}
         <h2 className="p-2 mt-10 text-3xl">{category?.name}の記事一覧</h2>
         {category.posts.map((post) => {
           return (

--- a/app/components/blog/CustomComponents.tsx
+++ b/app/components/blog/CustomComponents.tsx
@@ -1,0 +1,25 @@
+import { DOMNode, domToReact } from "html-react-parser";
+import CustomLink from "./blogDesignComponents/CustomLink";
+
+// blogのコンテンツにコンポーネントを使用するなら追加していく
+
+const CustomComponents = (domNode: DOMNode) => {
+  if (
+    domNode.type === "tag" &&
+    domNode.name === "next" &&
+    domNode.attribs &&
+    domNode.attribs.href
+  ) {
+    return (
+      <CustomLink href={domNode.attribs.href}>
+        {domToReact(domNode.children as DOMNode[], {
+          replace: CustomComponents,
+        })}
+      </CustomLink>
+    );
+  }
+
+  return domNode;
+};
+
+export default CustomComponents;

--- a/app/components/blog/TableOfContents.tsx
+++ b/app/components/blog/TableOfContents.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GenerateTocId } from "../lib/GenerateToc";
+
+type TocItem = {
+  id: string;
+  text: string;
+  tag: string;
+};
+
+type TableOfContentsProps = {
+  content: string | null;
+};
+
+const TableOfContents: React.FC<TableOfContentsProps> = ({ content }) => {
+  const [toc, setToc] = useState<TocItem[]>([]);
+
+  useEffect(() => {
+    if (content) {
+      setToc(GenerateTocId(content));
+    }
+  }, [content]);
+
+  return (
+    <div className="w-full max-w-[500px] p-6 mx-auto my-12 border rounded border-gray-300">
+      <p className="pb-1 text-center text-lg border-b  border-gray-300">
+        目次
+      </p>
+      <ul className="list-disc list-inside border-none" style={{ border: "none", padding: 0, margin: 0 }}>
+      {toc.map((item) => {
+          let className = "";
+          switch (item.tag) {
+            case "h2":
+              className = "list-none font-semibold mb-3";
+              break;
+            case "h3":
+              className = "ml-6 mb-2 marker:text-gray-500";
+              break;
+            default:
+              className = "list-none font-semibold mb-3";
+          }
+
+          return (
+            <li key={item.id} className={className}>
+              <a href={`#${item.id}`} style={{ color: "rgb(75 85 99)" }}>
+                {item.text}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default TableOfContents;

--- a/app/components/blog/blogContent/ArticleContentArea.tsx
+++ b/app/components/blog/blogContent/ArticleContentArea.tsx
@@ -1,22 +1,77 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import parse from "html-react-parser";
 import DOMPurify from "dompurify";
+import { AddGenerateContentId } from "../../lib/GenerateToc";
+import TableOfContents from "../TableOfContents";
+import CustomComponents from "../CustomComponents";
 
 type ArticleContentAreaProps = {
   content: string;
 };
 
 const ArticleContentArea: React.FC<ArticleContentAreaProps> = ({ content }) => {
-  const [sanitizedContent, setSanitizedContent] = useState("");
+  const [idContent, setIdContent] = useState("");
+  const [beforeContent, setBeforeContent] = useState("");
+  const [afterContent, setAfterContent] = useState("");
+  const [sanitizedBeforeContent, setSanitizedBeforeContent] = useState("");
+  const [sanitizedAfterContent, setSanitizedAfterContent] = useState("");
 
+  // 目次の為にIDを付与
   useEffect(() => {
-    const sanitized = DOMPurify.sanitize(content);
-    const formattedContent = sanitized.replace(/\n/g, "<br>");
-    setSanitizedContent(formattedContent);
+    if (content) {
+      const id = AddGenerateContentId(content);
+      setIdContent(id);
+    }
   }, [content]);
 
-  return <>{parse(sanitizedContent)}</>;
+  // 最初のh2タグの部分で分離
+  useEffect(() => {
+    if (idContent) {
+      const h2Index = idContent.indexOf("<h2");
+      if (h2Index !== -1) {
+        const before = idContent.slice(0, h2Index);
+        const after = idContent.slice(h2Index);
+
+        setBeforeContent(before);
+        setAfterContent(after);
+      } else {
+        setBeforeContent("idContent");
+        setAfterContent(idContent);
+      }
+    }
+  }, [idContent]);
+
+  useEffect(() => {
+    if (beforeContent) {
+      const sanitized = DOMPurify.sanitize(beforeContent, {
+        ADD_TAGS: ["next"],
+        ADD_ATTR: ["href"]
+      });
+      const formattedContent = sanitized.replace(/\n/g, "<br>");
+      setSanitizedBeforeContent(formattedContent);
+    }
+  }, [beforeContent]);
+
+  useEffect(() => {
+    if (afterContent) {
+      const sanitized = DOMPurify.sanitize(afterContent, {
+        ADD_TAGS: ["next"],
+        ADD_ATTR: ["href"]
+      });
+      const formattedContent = sanitized.replace(/\n/g, "<br>");
+      setSanitizedAfterContent(formattedContent);
+    }
+  }, [afterContent]);
+
+  return (
+    <>
+      {parse(sanitizedBeforeContent, { replace: CustomComponents })}
+      <TableOfContents content={content} />
+      {parse(sanitizedAfterContent, { replace: CustomComponents })}
+    </>
+  );
 };
+
 export default ArticleContentArea;

--- a/app/components/blog/blogDesignComponents/CustomLink.tsx
+++ b/app/components/blog/blogDesignComponents/CustomLink.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link"
+
+type CustomLinkProps = {
+    href: string;
+    children: React.ReactNode;
+}
+
+const CustomLink:React.FC<CustomLinkProps> = ({ href, children}) => {
+  return (
+    <Link href={href}>{children}</Link>
+  )
+}
+
+export default CustomLink

--- a/app/components/lib/GenerateToc.ts
+++ b/app/components/lib/GenerateToc.ts
@@ -1,0 +1,48 @@
+import { load } from "cheerio";
+
+type TocItem = {
+  id: string;
+  text: string;
+  tag: string;
+};
+
+export const GenerateTocId = (contents: string): TocItem[] => {
+  const $ = load(contents);
+  const toc: TocItem[] = [];
+
+  $("h2, h3").each((index, element) => {
+    let id = $(element).attr("id");
+    const text = $(element).text();
+    const tag = $(element).prop("tagName").toLowerCase();
+
+    if (!id) {
+      const generatedId = `${index}`;
+      $(element).attr("id", generatedId);
+      id = generatedId;
+    }
+
+    if (id) {
+      toc.push({ id, text, tag });
+    }
+  });
+
+  return toc;
+};
+
+export const AddGenerateContentId = (contents: string) => {
+  const $ = load(contents);
+
+  $("h2, h3").each((index, element) => {
+    let id = $(element).attr("id");
+
+    if (!id) {
+      const generatedId = `${index}`;
+      $(element).attr("id", generatedId);
+      id = generatedId;
+    }
+  });
+
+  return $.html();
+};
+
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -89,3 +89,22 @@ body {
     margin-bottom: 1rem;
     border: none;
   }
+
+  .blog ul {
+    width: 100%;
+    max-width: 500px;
+    list-style-type: disc;
+    list-style-position: inside;
+    border-width: 1px;
+    border-style: dashed;
+    border-color: gray;
+    border-radius: 4px;
+    padding: 1.5rem;
+    margin: 1.5rem auto;
+  }
+  
+  .blog li {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+  

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    images: {
+      domains: ['ybfrmhradztqizzobkvg.supabase.co'],
+    },
+  };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@supabase/supabase-js": "^2.42.4",
         "axios": "^1.6.8",
         "bcrypt": "^5.1.1",
+        "cheerio": "^1.0.0-rc.12",
         "dompurify": "^3.1.0",
         "framer-motion": "^11.1.7",
         "html-react-parser": "^5.1.10",
@@ -1968,6 +1969,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2117,6 +2123,60 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/chokidar": {
@@ -2274,6 +2334,32 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -5422,6 +5508,17 @@
         "set-blocking": "^2.0.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
@@ -5704,6 +5801,29 @@
       "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "dependencies": {
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-browserify": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@supabase/supabase-js": "^2.42.4",
     "axios": "^1.6.8",
     "bcrypt": "^5.1.1",
+    "cheerio": "^1.0.0-rc.12",
     "dompurify": "^3.1.0",
     "framer-motion": "^11.1.7",
     "html-react-parser": "^5.1.10",


### PR DESCRIPTION
ブログの以下のページに自動で目次が作成され表示されるよう変更

・個別記事のページ
・カテゴリのページ

cheeiroのライブラリを使用。
目次は１つ目の見出しの前に自動的に設置がされる。
(１つ目の見出しの手前と後でDBから取得した記事の内容を分離し、それぞれをsanitizeし表示している)
各見出しにIDが自動的に付与されることで目次が機能するようにしている。











