### PR TITLE
自動でデータ更新されるサイトマップの作成 / 修正(スラッグにハイフンを許可 / カテゴリのカードの画像)

### DIFF
--- a/app/(blog)/dashboard/layout.tsx
+++ b/app/(blog)/dashboard/layout.tsx
@@ -21,7 +21,7 @@ export default async function RootLayout({
           <ToastContext />
           <div className="flex bg-sky-50">
             <DashboardSideMenu />
-            <div className="flex justify-center items-center mx-auto w-full max-w-[1200px] ml-0 sm:ml-96 bg-white border rounded border-gray-200 p-5 mt-8">
+            <div className="flex justify-center items-start w-full max-w-[1200px] min-h-[93vh] p-5 my-8 mx-auto ml-0 sm:ml-96 bg-white border rounded border-gray-200">
               <div className="w-full">{children}</div>
             </div>
           </div>

--- a/app/action/action-category.ts
+++ b/app/action/action-category.ts
@@ -24,7 +24,7 @@ const schema = z.object({
   slug: z
     .string()
     .min(1, { message: "スラッグの入力は必須です。" })
-    .regex(/^[a-z0-9]+$/, {
+    .regex(/^[a-z0-9-]+$/, {
       message: "スラッグは半角小文字の英数字で入力してください",
     }),
   content: z.string().optional(),

--- a/app/action/action-post.ts
+++ b/app/action/action-post.ts
@@ -28,7 +28,7 @@ const schema = z.object({
   slug: z
     .string()
     .min(1, { message: "スラッグの入力は必須です。" })
-    .regex(/^[a-z0-9]+$/, {
+    .regex(/^[a-z0-9-]+$/, {
       message: "スラッグは半角小文字の英数字で入力してください",
     }),
   description: z.string().min(1, { message: "記事の説明の入力は必須です" }),
@@ -163,7 +163,7 @@ export const deletePost = async (data: FormData) => {
     });
     revalidatePath(`/`);
     revalidatePath(`/dashboard/post`);
-    revalidatePath(`/${post?.category.slug}/${post?.slug}`);  
+    revalidatePath(`/${post?.category.slug}/${post?.slug}`);
     await revalidatePostsAndCategories();
 
     if (post?.postImage?.url) {
@@ -283,10 +283,15 @@ export const updatePost = async (
         });
         console.log("関連する画像ライブラリの削除に成功しました。");
       } catch (error) {
-        console.error("関連する画像ライブラリの削除中にエラーが発生しました:", error);
-        return { message: "関連する画像ライブラリの削除中にエラーが発生しました" };
+        console.error(
+          "関連する画像ライブラリの削除中にエラーが発生しました:",
+          error
+        );
+        return {
+          message: "関連する画像ライブラリの削除中にエラーが発生しました",
+        };
       }
-    } 
+    }
   }
 
   try {

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -18,15 +18,18 @@ const Footer = () => {
         />
       </div>
       <footer>
-        <div className="bg-blue-500 min-h-[68px] w-full flex flex-grow bottom-0 items-end justify-center">
-          <ul className="text-xs text-center mb-3">
-            <li className="mb-2 text-white">
+        <div className="bg-blue-500 min-h-[68px] w-full flex flex-col items-center justify-center bottom-0">
+          <ul className="flex text-xs text-center">
+            <li className="mx-6 text-white">
               <Link href="/privacypolicy">プライバシーポリシー・免責事項</Link>
             </li>
-            <li className="text-black">
-              &copy;サイトタイトル
+            <li className="mb-2 text-white">
+              <Link href="/sitemaps">サイトマップ</Link>
             </li>
           </ul>
+          <span className="text-xs text-black">
+            &copy;サイトタイトル
+          </span>
         </div>
       </footer>
     </>

--- a/app/components/blog/Card.tsx
+++ b/app/components/blog/Card.tsx
@@ -18,53 +18,53 @@ const Card: React.FC<CardProps> = ({ post }) => {
   return (
     <>
       {post.draft && (
-        <div className="flex flex-wrap md:flex-nowrap  border w-full border-gray-400 my-8 hover:bg-gray-100">
-          {post.postImage ? (
-            <div className="w-full md:w-auto pt-3 md:pt-0 min-w-[260px]">
-              <Image
-                src={post.postImage.url}
-                alt={post.postImage.altText}
-                width={260}
-                height={171}
-                style={{
-                  width: "260px",
-                  height: "auto",
-                }}
-                className="block mx-auto"
-              />
-            </div>
-          ) : (
-            <div className="w-full md:w-auto pt-3 md:pt-0 min-w-[260px]">
-              <Image
-                src="/no_image.jpg"
-                alt="画像の準備中"
-                width={328}
-                height={213}
-                style={{
-                  width: "261px",
-                  height: "auto",
-                }}
-                className="block mx-auto"
-              />
-            </div>
-          )}
-          <div className="w-full md:flex-auto px-4 py-3 card">
-            {post.title && post.title.length > 31 ? (
-              <h3 className="text-lg font-bold text-gray-700 mb-4">
-                {post.title.slice(0, 31)}...
-              </h3>
-            ) : (
-              <h3 className="text-lg font-bold text-gray-700 mb-4 border-none ">
-                {post.title}
-              </h3>
-            )}
-            <p className="text-gray-600">
-              {post.description.length > 72
-                ? `${post.description.slice(0, 72)}...`
-                : post.description}
-            </p>
-          </div>
-        </div>
+                <div className="flex flex-wrap md:flex-nowrap  border w-full border-gray-400 my-8 hover:bg-gray-100">
+                {post.postImage ? (
+                  <div className="w-full md:w-auto pt-3 md:pt-0 min-w-[300px]">
+                    <Image
+                      src={post.postImage.url}
+                      alt={post.postImage.altText}
+                      width={300}
+                      height={200}
+                      style={{
+                        width: "300",
+                        height: "auto",
+                      }}
+                      className="block mx-auto"
+                    />
+                  </div>
+                ) : (
+                  <div className="w-full md:w-auto pt-3 md:pt-0 min-w-[300px]">
+                    <Image
+                      src="/no_image.jpg"
+                      alt="画像の準備中"
+                      width={300}
+                      height={200}
+                      style={{
+                        width: "300",
+                        height: "auto",
+                      }}
+                      className="block mx-auto"
+                    />
+                  </div>
+                )}
+                <div className="w-full md:flex-auto px-4 py-3 card">
+                  {post.title && post.title.length > 31 ? (
+                    <h3 className="text-lg font-bold text-gray-700 mb-4">
+                      {post.title.slice(0, 31)}...
+                    </h3>
+                  ) : (
+                    <h3 className="text-lg font-bold text-gray-700 mb-4 border-none ">
+                      {post.title}
+                    </h3>
+                  )}
+                  <p className="text-gray-600 mb-0">
+                    {post.description.length > 72
+                      ? `${post.description.slice(0, 72)}...`
+                      : post.description}
+                  </p>
+                </div>
+              </div>
       )}
     </>
   );

--- a/app/components/blog/blogContent/ArticleTop.tsx
+++ b/app/components/blog/blogContent/ArticleTop.tsx
@@ -13,12 +13,12 @@ const ArticleTop: React.FC<ArticleTopProps> = ({ src, alt }) => {
           src={src}
           alt={alt}
           width={650}
-          height={428}
+          height={430}
           priority
           style={{
             maxWidth: "100%",
             height: "auto",
-            aspectRatio: "650 / 428",
+            aspectRatio: "650 / 430",
           }}
           sizes="100vw"
           className="block mx-auto mb-8 max-w-[650px] max-h-[430px]"

--- a/app/components/blog/dashboard/FormPost.tsx
+++ b/app/components/blog/dashboard/FormPost.tsx
@@ -85,11 +85,15 @@ const FormPost: React.FC<FormPostProps> = ({
 
     const sanitizedFormData = new FormData();
     for (const [key, value] of formData.entries()) {
-      let sanitizedValue = value;
-      if (key !== "image") {
-        sanitizedValue = DOMPurify.sanitize(value.toString());
+      if (key !== "image" && typeof value === "string") {
+        const sanitizedValue = DOMPurify.sanitize(value, {
+          ADD_TAGS: ["next"],
+          ADD_ATTR: ["href"]
+        });
+        sanitizedFormData.append(key, sanitizedValue);
+      } else {
+        sanitizedFormData.append(key, value);
       }
-      sanitizedFormData.append(key, sanitizedValue);
     }
     sanitizedFormData.set("draft", isDraft.toString());
 

--- a/app/components/lib/BlogServiceMany.ts
+++ b/app/components/lib/BlogServiceMany.ts
@@ -1,7 +1,7 @@
 import prisma from "@/app/components/lib/prisma";
 
 export async function getPosts(includeOptions?: string, take?: number,) {
-  let include: {
+  const include: {
     category?: boolean;
     postImage?: boolean;
   } = { category: false, postImage: false };
@@ -50,7 +50,7 @@ export async function getPosts(includeOptions?: string, take?: number,) {
 }
 
 export async function getCategories(includeOptions?: string) {
-  let include: {
+  const include: {
     posts?: boolean;
     postImage?: boolean;
   } = { posts: false, postImage: false };

--- a/app/components/lib/BlogServiceUnique.ts
+++ b/app/components/lib/BlogServiceUnique.ts
@@ -5,7 +5,7 @@ export async function getPost(
   whereValue?: string,
   includeOptions?: string
 ) {
-  let include: {
+  const include: {
     category?: boolean;
     postImage?: boolean;
   } = { category: false, postImage: false };
@@ -52,10 +52,14 @@ export async function getCategory(
   whereValue?: string,
   includeOptions?: string
 ) {
-  let include: {
-    posts?: boolean;
+  const include: {
+    posts?: {
+      include: {
+        postImage: boolean;
+      };
+    } | boolean;
     postImage?: boolean;
-  } = { posts: false, postImage: false };
+  } = {};
 
   switch (includeOptions) {
     case "posts":
@@ -65,7 +69,11 @@ export async function getCategory(
       include.postImage = true;
       break;
     case "postsAndPostImage":
-      include.posts = true;
+      include.posts = {
+        include: {
+          postImage: true,
+        },
+      };
       include.postImage = true;
       break;
     default:

--- a/app/sitemaps/layout.tsx
+++ b/app/sitemaps/layout.tsx
@@ -4,10 +4,7 @@ import Header from "../components/Header";
 import Footer from "../components/Footer";
 
 export const metadata: Metadata = {
-  title: "プライバシーポリシー・免責事項 | 編集箇所サイト名",
-  robots: {
-    index: false,
-  },
+  title: "サイトマップ | 編集箇所サイト名",
 };
 
 export default async function RootLayout({

--- a/app/sitemaps/layout.tsx
+++ b/app/sitemaps/layout.tsx
@@ -1,0 +1,29 @@
+import { Metadata } from "next";
+
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+export const metadata: Metadata = {
+  title: "プライバシーポリシー・免責事項 | 編集箇所サイト名",
+  robots: {
+    index: false,
+  },
+};
+
+export default async function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <Header />
+      <main className="bg-sky-50">
+        <div className="main-contents-area rounded">
+          <div className="w-full px-1 md:px-8">{children}</div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/sitemaps/page.tsx
+++ b/app/sitemaps/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { getCategories } from "../components/lib/BlogServiceMany";
+
+const page = async () => {
+    const categories = await getCategories("posts");
+    return (
+        <>
+          <h2>サイトマップ</h2>
+          <p className="font-semibold text-[#2a7bdf]">
+            <Link href="/memorybook">
+              国内旅行・海外旅行の旅程表作成しおりアプリ「旅のメモリーブック」
+            </Link>
+          </p>
+          <div className="p-4 mb-6 border border-dashed border-gray-400">
+            <p className="font-semibold text-[#2a7bdf]">
+              <Link href="/">
+                英語なしで最高の海外旅行の思い出を作る「トラベルメモリー」
+              </Link>
+            </p>
+            {categories.map((category) => {
+              return (
+                <div className="px-8" key={category.id}>
+                  <ul className="text-[#2a7bdf]">
+                    <li className="my-4 font-semibold">
+                      <Link href={`/${category.slug}`}>{category.name}</Link>
+                    </li>
+                    {category.posts.map((post) => (
+                      <li key={post.id} className="my-4 ml-4 list-disc list-inside">
+                        <Link href={`/${category.slug}/${post.slug}`}>
+                          {post.title}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      );
+}
+
+export default page


### PR DESCRIPTION
## サイトマップの作成

フッターにサイトマップページへのリンクを追加
サイトマップはDBから取得されたデータを利用するので自動で更新がされていくように実装。

## 修正

- スラッグにハイフンが使用できるように変更
- カテゴリのカードの画像
- サニタイズで特定のタグのみを許可していたのを特定のタグを許可に変更

スラッグがハイフン(-)が許可されないようにバリデーションされていたので利用できるように変更。
カテゴリページの下部のカードリンクで画像が正常に表示されていなかったので、表示がされるように変更。
サニタイズに特定のタグのみを許可していたのを、指定した特定のタグを許可に変更にし、今後デザインコンポーネントが作成された際などに、簡単に追加ができるように実装。



