### PR TITLE
サーバー側でsesstionのuserRoleで権限確認 / 記事・画像・カテゴリ・メモのCRUD時に権限を確認

### DIFF
--- a/app/action/action-category.ts
+++ b/app/action/action-category.ts
@@ -9,6 +9,8 @@ import { FileSaveUtils } from "../components/lib/FileSaveUtils";
 import { validateFile } from "../components/lib/ValidateFile";
 import { revalidatePostsAndCategories } from "../components/lib/revalidatePostsAndCategories";
 import { getCategory } from "../components/lib/BlogServiceUnique";
+import { getCurrentUserRole } from "../components/lib/getCurrentUser";
+import { checkUserRole } from "../components/lib/checkUserRole";
 
 type FormState = {
   message?: string | null;
@@ -160,8 +162,13 @@ export const deleteCategory = async (data: FormData) => {
       });
       console.log("関連する画像ライブラリの削除に成功しました。");
     } catch (error) {
-      console.error("関連する画像ライブラリの削除中にエラーが発生しました:", error);
-      return { message: "関連する画像ライブラリの削除中にエラーが発生しました" };
+      console.error(
+        "関連する画像ライブラリの削除中にエラーが発生しました:",
+        error
+      );
+      return {
+        message: "関連する画像ライブラリの削除中にエラーが発生しました",
+      };
     }
   }
 

--- a/app/action/action-category.ts
+++ b/app/action/action-category.ts
@@ -41,6 +41,13 @@ const ImageSchema = z.object({
 });
 
 export const addCategory = async (state: FormState, data: FormData) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const name = data.get("name") as string;
   const slug = data.get("slug") as string;
   const content = data.get("content") as string;
@@ -138,6 +145,13 @@ export const addCategory = async (state: FormState, data: FormData) => {
 };
 
 export const deleteCategory = async (data: FormData) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const id = data.get("id") as string;
 
   const category = await getCategory("id", id, "postImage");
@@ -199,6 +213,13 @@ export const updateCategory = async (
   state: FormState,
   data: FormData
 ) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+  
   const name = data.get("name") as string;
   const content = data.get("content") as string;
   const description = data.get("description") as string;

--- a/app/action/action-dashboard.ts
+++ b/app/action/action-dashboard.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import prisma from "../components/lib/prisma";
 import { z } from "zod";
+import { checkUserRole } from "../components/lib/checkUserRole";
 
 type FormState = {
   message?: string | null;
@@ -19,6 +20,13 @@ const schema = z.object({
 });
 
 export const addDashboardMemo = async (state: FormState, data: FormData) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const name = data.get("name") as string;
   const content = data.get("content") as string;
 
@@ -52,6 +60,13 @@ export const addDashboardMemo = async (state: FormState, data: FormData) => {
 };
 
 export const deleteDashboardMemo = async (data: FormData) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const id = data.get("id") as string;
 
   try {
@@ -68,7 +83,18 @@ export const deleteDashboardMemo = async (data: FormData) => {
   redirect("/dashboard");
 };
 
-export const updateDashboardMemo = async (id: number, state: FormState, data: FormData) => {
+export const updateDashboardMemo = async (
+  id: number,
+  state: FormState,
+  data: FormData
+) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const name = data.get("name") as string;
   const content = data.get("content") as string;
 
@@ -85,7 +111,7 @@ export const updateDashboardMemo = async (id: number, state: FormState, data: Fo
     console.log(errors);
     return errors;
   }
-  
+
   try {
     await prisma.dashboardMemo.update({
       where: {

--- a/app/action/action-post.ts
+++ b/app/action/action-post.ts
@@ -9,6 +9,7 @@ import { FileSaveUtils } from "../components/lib/FileSaveUtils";
 import { validateFile } from "../components/lib/ValidateFile";
 import { revalidatePostsAndCategories } from "../components/lib/revalidatePostsAndCategories";
 import { getPost } from "../components/lib/BlogServiceUnique";
+import { checkUserRole } from "../components/lib/checkUserRole";
 
 type FormState = {
   message?: string | null;
@@ -42,6 +43,13 @@ const ImageSchema = z.object({
 });
 
 export const addPost = async (state: FormState, data: FormData) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const title = data.get("title") as string;
   const content = data.get("content") as string;
   const description = data.get("description") as string;
@@ -138,6 +146,13 @@ export const addPost = async (state: FormState, data: FormData) => {
 };
 
 export const deletePost = async (data: FormData) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const id = data.get("id") as string;
 
   const post = await getPost("id", id, "categoryAndPostImage");
@@ -183,6 +198,13 @@ export const updatePost = async (
   state: FormState,
   data: FormData
 ) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const title = data.get("title") as string;
   const content = data.get("content") as string;
   const description = data.get("description") as string;

--- a/app/action/action-postImage.ts
+++ b/app/action/action-postImage.ts
@@ -9,6 +9,7 @@ import { promises as fsPromises } from "fs";
 import { FileSaveUtils } from "../components/lib/FileSaveUtils";
 import { validateFile } from "../components/lib/ValidateFile";
 import { getPostImage } from "../components/lib/BlogServiceUnique";
+import { checkUserRole } from "../components/lib/checkUserRole";
 
 const { unlink } = fsPromises;
 
@@ -32,6 +33,13 @@ const updateSchema = z.object({
 });
 
 export const addPostImage = async (state: FormState, data: FormData) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const image = data.get("image") as File;
   const altText = data.get("altText") as string;
   const validatedFields = schema.safeParse({
@@ -81,6 +89,13 @@ export const addPostImage = async (state: FormState, data: FormData) => {
 };
 
 export const deletePostImage = async (data: FormData) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const id = data.get("id") as string;
 
   const postImage = await getPostImage(id);
@@ -120,6 +135,13 @@ export const updatePostImage = async (
   state: FormState,
   data: FormData
 ) => {
+  const isAdmin = await checkUserRole("admin");
+
+  if (!isAdmin) {
+    console.error("管理者権限が必要です。");
+    return { message: "管理者権限がありません。" };
+  }
+
   const image = data.get("image") as File;
   const altText = data.get("altText") as string;
 
@@ -151,7 +173,6 @@ export const updatePostImage = async (
       return { message: "altTextを更新する際にエラーが発生しました" };
     }
   }
-
 
   // 画像がある場合は保存してfileUrlを変更
   if (image && image.size > 0) {

--- a/app/components/lib/checkUserRole.ts
+++ b/app/components/lib/checkUserRole.ts
@@ -1,0 +1,15 @@
+import { getCurrentUserRole } from "./getCurrentUser";
+
+export const checkUserRole = async (role: string) => {
+    try {
+    const userRole = await getCurrentUserRole();
+    if (!userRole || userRole !== role) {
+      console.error(`${role}権限が必要です。`);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error("権限の確認中にエラーが発生しました:", error);
+    return false;
+  }
+};

--- a/app/components/lib/getCurrentUser.ts
+++ b/app/components/lib/getCurrentUser.ts
@@ -22,6 +22,7 @@ export async function getCurrentUser() {
 
     return response;
   } catch (error) {
+    console.error("セッションの取得に失敗しました:", error);
     return null;
   }
 }
@@ -47,6 +48,7 @@ export async function getCurrentUserId() {
     const userId = response.id;
     return userId;
   } catch (error) {
+    console.error("セッションの取得に失敗しました:", error);
     return null;
   }
 }
@@ -63,6 +65,7 @@ export async function getCurrentUserRole() {
 
     return userRole;
   } catch (error) {
+    console.error("セッションの取得に失敗しました:", error);
     return null;
   }
 }

--- a/app/components/lib/getCurrentUser.ts
+++ b/app/components/lib/getCurrentUser.ts
@@ -50,3 +50,19 @@ export async function getCurrentUserId() {
     return null;
   }
 }
+
+export async function getCurrentUserRole() {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.role) {
+      return null;
+    }
+
+    const userRole = session?.user.role
+
+    return userRole;
+  } catch (error) {
+    return null;
+  }
+}

--- a/app/components/util/authOptions.ts
+++ b/app/components/util/authOptions.ts
@@ -80,6 +80,7 @@ export const authOptions: NextAuthOptions = {
           return {
             id: ADMIN_USERNAME || "",
             role: "admin",
+            email: username || null,
           };
         } else if (username !== ADMIN_USERNAME) {
           throw new Error("ユーザー名が間違っています");
@@ -99,6 +100,12 @@ export const authOptions: NextAuthOptions = {
         token.role = u.role;
       }
       return token;
+    },
+    session: async ({ session, token }) => {
+      if (token.user) {
+        session.user = token.user;
+      }
+      return session;
     },
   },
   pages: {

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,9 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      role?: string;
+    } & DefaultSession["user"];
+  }
+}


### PR DESCRIPTION
## サーバー側でsesstionのuserRoleで権限確認

- sessionにuserRoleを含めるようにしてroleを取得する関数の作成
- userRoleをチェックする関数を作成

userRoleをsessionから取得して、権限があるかの確認を出来るように関数の作成。

## 記事・画像・カテゴリ・メモのCRUD時に権限を確認

- カテゴリの作成削除編集時にsessionのroleで権限を確認
- ダッシュボードメモの作成削除編集時にsessionのroleで権限を確認
- 記事のの作成削除編集時にsessionのroleで権限を確認
- 画像の作成削除編集時にsessionのroleで権限を確認

userRoleを確認して、それぞれ作成・削除・編集を出来る権限があるかの確認をしている。
権限が無い場合は変更が行えないようになっている。

